### PR TITLE
Support more inputs and globs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,14 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "arrayvec"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,6 +180,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-channel 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-epoch 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-utils 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-epoch 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "csv"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,6 +368,7 @@ dependencies = [
 name = "falconeri-worker"
 version = "0.1.8"
 dependencies = [
+ "crossbeam 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "falconeri_common 0.1.8",
@@ -451,6 +516,15 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "lock_api"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "log"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,6 +570,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "migrations_internals"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,6 +593,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "nodrop"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "num-integer"
 version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,6 +609,14 @@ dependencies = [
 name = "num-traits"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "num_cpus"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "openssl"
@@ -553,6 +645,35 @@ dependencies = [
  "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "owning_ref"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -833,6 +954,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "semver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -892,6 +1018,19 @@ dependencies = [
  "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "smallvec"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "strsim"
@@ -1061,6 +1200,14 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unreachable"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "utf8-ranges"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1083,6 +1230,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "vec_map"
 version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "void"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1151,6 +1303,7 @@ dependencies = [
 "checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
+"checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
 "checksum backoff 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b7bd67d02cc9dfe9bb1891cb6b4f0169f53cdf0a78b07276ab2141452aaf5789"
@@ -1169,6 +1322,11 @@ dependencies = [
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum common_failures 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c84afb517ac0988b7e049e06c51511716f80d0f0233972fca666d3f14f80d8fb"
+"checksum crossbeam 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad4c7ea749d9fb09e23c5cb17e3b70650860553a0e2744e38446b1803bf7db94"
+"checksum crossbeam-channel 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "137bc235f622ffaa0428e3854e24acb53291fc0b3ff6fb2cb75a8be6fb02f06b"
+"checksum crossbeam-deque 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "05e44b8cf3e1a625844d1750e1f7820da46044ff6d28f4d43e455ba3e5bb2c13"
+"checksum crossbeam-epoch 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f10a4f8f409aaac4b16a5474fb233624238fcdeefb9ba50d5ea059aab63ba31c"
+"checksum crossbeam-utils 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "41ee4864f4797060e52044376f7d107429ce1fb43460021b126424b7180ee21a"
 "checksum csv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "9fd1c44c58078cfbeaf11fbb3eac9ae5534c23004ed770cc4bfb48e658ae4f04"
 "checksum csv-core 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa5cdef62f37e6ffe7d1f07a381bc0db32b7a3ff1cac0de56cb0d81e71f53d65"
 "checksum diesel 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "66d7d3a2f8a24763a1a52b5324737b4d24141bb294440ed9094db60bd6cd29ee"
@@ -1197,19 +1355,26 @@ dependencies = [
 "checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
 "checksum libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)" = "48450664a984b25d5b479554c29cc04e3150c97aa4c01da5604a2d4ed9151476"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
+"checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum magnet_derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9ac17d4ebcbfeef374dad8a4a660eac63ee1c2aab9f7cf47afdc07008f05e4aa"
 "checksum magnet_schema 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "66371076edddff3e3f36ca83c289a7ac52d1b23bb05aeb1859ec04a2dd398fdb"
 "checksum maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08cbb6b4fef96b6d77bfc40ec491b1690c779e77b05cd9f07f787ed376fd4c43"
 "checksum md5 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "79c56d6a0b07f9e19282511c83fc5b086364cbae4ba8c7d5f190c3d9b0425a48"
 "checksum memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e1dd4eaac298c32ce07eb6ed9242eda7d82955b9170b7d6db59b2e02cc63fcb8"
+"checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum migrations_internals 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8089920229070f914b9ce9b07ef60e175b2b9bc2d35c3edd8bf4433604e863b9"
 "checksum migrations_macros 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1664412abf7db2b8a6d58be42a38b099780cc542b5b350383b805d88932833fe"
+"checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
+"checksum num_cpus 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a69d464bdc213aaaff628444e99578ede64e9c854025aa43b9796530afa9238"
 "checksum openssl 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)" = "ec7bd7ca4cce6dbdc77e7c1230682740d307d1218a87fb0349a571272be749f9"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.40 (registry+https://github.com/rust-lang/crates.io-index)" = "1bb974e77de925ef426b6bc82fce15fd45bdcbeb5728bffcfc7cdeeb7ce1c2d6"
+"checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
+"checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
+"checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
 "checksum pest 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "54f0c72a98d8ab3c99560bfd16df8059cc10e1f9a8e83e6e3b97718dd766e9c3"
 "checksum pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
 "checksum pest_generator 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "63120576c4efd69615b5537d3d052257328a4ca82876771d6944424ccfd9f646"
@@ -1242,6 +1407,7 @@ dependencies = [
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
 "checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
+"checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)" = "534b8b91a95e0f71bca3ed5824752d558da048d4248c91af873b63bd60519752"
@@ -1249,6 +1415,8 @@ dependencies = [
 "checksum serde_json 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)" = "574378d957d6dcdf1bbb5d562a15cbd5e644159432f84634b94e485267abbcc7"
 "checksum serde_yaml 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0887a8e097a69559b56aa2526bf7aff7c3048cf627dff781f0b56a6001534593"
 "checksum sha-1 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51b9d1f3b5de8a167ab06834a7c883bd197f2191e1dda1a22d9ccfeedbf9aded"
+"checksum smallvec 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "88aea073965ab29f6edb5493faf96ad662fb18aa9eeb186a3b7057951605ed15"
+"checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum structopt 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "670ad348dc73012fcf78c71f06f9d942232cdd4c859d4b6975e27836c3efc0c3"
 "checksum structopt-derive 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "ef98172b1a00b0bec738508d3726540edcbd186d50dfd326f2b1febbb3559f04"
@@ -1271,10 +1439,12 @@ dependencies = [
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
 "checksum uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e1436e58182935dcd9ce0add9ea0b558e8a87befe01c1a301e6020aeb0876363"
 "checksum vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@ name = "aho-corasick"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -24,14 +24,14 @@ name = "atty"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "autocfg"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -47,21 +47,21 @@ name = "backtrace"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "backtrace-sys 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.26"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -69,7 +69,7 @@ name = "base64"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -91,17 +91,17 @@ name = "bson"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "md5 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "try_from 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -112,7 +112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byteorder"
-version = "1.2.7"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -122,7 +122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cc"
-version = "1.0.26"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -137,8 +137,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -168,7 +168,7 @@ name = "common_failures"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -177,7 +177,7 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "csv-core 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -185,40 +185,40 @@ name = "csv-core"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "diesel"
-version = "1.3.3"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "diesel_derives 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel_derives 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pq-sys 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "diesel_derives"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.13.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "diesel_migrations"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "migrations_internals 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "migrations_macros 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "migrations_internals 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "migrations_macros 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -253,21 +253,21 @@ dependencies = [
 
 [[package]]
 name = "failure"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "failure_derive"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -283,7 +283,7 @@ dependencies = [
  "base64 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bson 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "falconeri_common 0.1.8",
  "handlebars 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -292,9 +292,9 @@ dependencies = [
  "openssl 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -305,7 +305,7 @@ name = "falconeri-worker"
 version = "0.1.8"
 dependencies = [
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "falconeri_common 0.1.8",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -324,18 +324,18 @@ dependencies = [
  "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "common_failures 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "diesel 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "diesel_migrations 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel_migrations 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "magnet_derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "magnet_schema 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -386,18 +386,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "pest 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "pest_derive 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pest 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "heck"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -413,7 +413,7 @@ name = "hostname"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "winutil 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -442,7 +442,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.45"
+version = "0.2.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -463,8 +463,8 @@ name = "magnet_derive"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -488,28 +488,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "migrations_internals"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "diesel 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "migrations_macros"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "migrations_internals 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "migrations_internals 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -536,7 +535,7 @@ dependencies = [
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.9.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -550,15 +549,15 @@ name = "openssl-sys"
 version = "0.9.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pest"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ucd-trie 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -566,32 +565,32 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "pest 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "pest_generator 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pest 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pest_generator 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pest_generator"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "pest 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "pest_meta 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pest 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pest_meta 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.0.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "pest 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pest 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha-1 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -623,15 +622,7 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "proc-macro2"
-version = "0.4.24"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -649,18 +640,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quote"
-version = "0.5.2"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "quote"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -669,17 +652,19 @@ version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -690,36 +675,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand"
-version = "0.6.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_chacha 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_os 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_pcg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_xorshift 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -752,6 +736,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_os"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rand_pcg"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,7 +759,15 @@ dependencies = [
 
 [[package]]
 name = "rand_xorshift"
-version = "0.1.0"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -770,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.44"
+version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -778,7 +783,7 @@ name = "redox_termios"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "redox_syscall 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -787,7 +792,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -803,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -842,28 +847,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.82"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.82"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.33"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -873,7 +878,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
  "yaml-rust 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -907,10 +912,10 @@ name = "structopt-derive"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -925,31 +930,21 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "0.13.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "syn"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "syn"
-version = "0.15.23"
+version = "0.15.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -966,9 +961,9 @@ name = "synstructure"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -977,7 +972,7 @@ name = "term"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -994,8 +989,8 @@ name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1017,11 +1012,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.41"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1076,8 +1071,8 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1088,11 +1083,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "vec_map"
 version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "version_check"
-version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1162,18 +1152,18 @@ dependencies = [
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
-"checksum autocfg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4e5f34df7a019573fb8bdc7e24a2bfebe51a2a1d6bfdbaeccedb3c41fc574727"
+"checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
 "checksum backoff 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b7bd67d02cc9dfe9bb1891cb6b4f0169f53cdf0a78b07276ab2141452aaf5789"
 "checksum backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b5b493b66e03090ebc4343eb02f94ff944e0cbc9ac6571491d170ba026741eb5"
-"checksum backtrace-sys 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "3fcce89e5ad5c8949caa9434501f7b55415b3e7ad5270cb88c75a8d35e8f1279"
+"checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
 "checksum base64 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "621fc7ecb8008f86d7fb9b95356cd692ce9514b80a86d85b397f32a22da7b9e2"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
 "checksum bson 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8984b7b33b1f8ac97468df3cefa76c7035abb0786473aa2a437dea0c72855702"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
-"checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
+"checksum byteorder 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60f0b0d4c0a382d2734228fd12b5a6b5dac185c60e938026fd31b265b94f9bd2"
 "checksum cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "926013f2860c46252efceabb19f4a6b308197505082c609025aa6706c011d427"
-"checksum cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "389803e36973d242e7fecb092b2de44a3d35ac62524b3b9339e51d577d668e02"
+"checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
@@ -1181,15 +1171,15 @@ dependencies = [
 "checksum common_failures 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c84afb517ac0988b7e049e06c51511716f80d0f0233972fca666d3f14f80d8fb"
 "checksum csv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "9fd1c44c58078cfbeaf11fbb3eac9ae5534c23004ed770cc4bfb48e658ae4f04"
 "checksum csv-core 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa5cdef62f37e6ffe7d1f07a381bc0db32b7a3ff1cac0de56cb0d81e71f53d65"
-"checksum diesel 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "164080ac16a4d1d80a50f0a623e4ddef41cb2779eee85bcc76907d340dfc98cc"
-"checksum diesel_derives 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "03bcaf77491f53e400d5ee3bdd57142ea4e1c47fe9217b3361ff9a76ca0e3d37"
-"checksum diesel_migrations 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b42c35d1ce9e8d57a3e7001b4127f2bc1b073a89708bb7019f5be27c991c28"
+"checksum diesel 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "66d7d3a2f8a24763a1a52b5324737b4d24141bb294440ed9094db60bd6cd29ee"
+"checksum diesel_derives 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "62a27666098617d52c487a41f70de23d44a1dc1f3aa5877ceba2790fb1f1cab4"
+"checksum diesel_migrations 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3cde8413353dc7f5d72fa8ce0b99a560a359d2c5ef1e5817ca731cd9008f4c"
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
 "checksum encode_unicode 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "90b2c9496c001e8cb61827acdefad780795c42264c137744cae6f7d9e3450abd"
 "checksum env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "afb070faf94c85d17d50ca44f6ad076bce18ae92f0037d350947240a36e9d42e"
-"checksum failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6dd377bcc1b1b7ce911967e3ec24fa19c3224394ec05b54aa7b083d498341ac7"
-"checksum failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "64c2d913fe8ed3b6c6518eedf4538255b989945c14c2a7d5cbff62a5e2120596"
+"checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
+"checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
@@ -1198,74 +1188,73 @@ dependencies = [
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum handlebars 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d82e5750d8027a97b9640e3fefa66bbaf852a35228e1c90790efd13c4b09c166"
-"checksum heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea04fa3ead4e05e51a7c806fc07271fdbde4e246a6c6d1efd52e72230b771b82"
+"checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "21ceb46a83a85e824ef93669c8b390009623863b5c195d1ba747292c0c72f94e"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
-"checksum libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)" = "2d2857ec59fadc0773853c664d2d18e7198e83883e7060b63c924cb077bd5c74"
+"checksum libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)" = "48450664a984b25d5b479554c29cc04e3150c97aa4c01da5604a2d4ed9151476"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum magnet_derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9ac17d4ebcbfeef374dad8a4a660eac63ee1c2aab9f7cf47afdc07008f05e4aa"
 "checksum magnet_schema 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "66371076edddff3e3f36ca83c289a7ac52d1b23bb05aeb1859ec04a2dd398fdb"
 "checksum maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08cbb6b4fef96b6d77bfc40ec491b1690c779e77b05cd9f07f787ed376fd4c43"
 "checksum md5 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "79c56d6a0b07f9e19282511c83fc5b086364cbae4ba8c7d5f190c3d9b0425a48"
-"checksum memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "db4c41318937f6e76648f42826b1d9ade5c09cafb5aef7e351240a70f39206e9"
-"checksum migrations_internals 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8cf7c8c4f83fa9f47440c0b4af99973502de55e6e7b875f693bd263e03f93e7e"
-"checksum migrations_macros 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "79f12499ef7353bdeca2d081bc61edd8351dac09a33af845952009b5a3d68c1a"
+"checksum memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e1dd4eaac298c32ce07eb6ed9242eda7d82955b9170b7d6db59b2e02cc63fcb8"
+"checksum migrations_internals 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8089920229070f914b9ce9b07ef60e175b2b9bc2d35c3edd8bf4433604e863b9"
+"checksum migrations_macros 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1664412abf7db2b8a6d58be42a38b099780cc542b5b350383b805d88932833fe"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum openssl 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)" = "ec7bd7ca4cce6dbdc77e7c1230682740d307d1218a87fb0349a571272be749f9"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.40 (registry+https://github.com/rust-lang/crates.io-index)" = "1bb974e77de925ef426b6bc82fce15fd45bdcbeb5728bffcfc7cdeeb7ce1c2d6"
-"checksum pest 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a677051ad923732bb5c70f2d45f8985a96e3eee2e2bff86697e3b11b0c3fcfde"
-"checksum pest_derive 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b76f477146419bc539a63f4ef40e902166cb43b3e51cecc71d9136fd12c567e7"
-"checksum pest_generator 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ebee4e9680be4fd162e6f3394ae4192a6b60b1e4d17d845e631f0c68d1a3386"
-"checksum pest_meta 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1f6d5f6f0e6082578c86af197d780dc38328e3f768cec06aac9bc46d714e8221"
+"checksum pest 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "54f0c72a98d8ab3c99560bfd16df8059cc10e1f9a8e83e6e3b97718dd766e9c3"
+"checksum pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
+"checksum pest_generator 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "63120576c4efd69615b5537d3d052257328a4ca82876771d6944424ccfd9f646"
+"checksum pest_meta 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f5a3492a4ed208ffc247adcdcc7ba2a95be3104f58877d0d02f0df39bf3efb5e"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum pq-sys 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "6ac25eee5a0582f45a67e837e350d784e7003bd29a5f460796772061ca49ffda"
 "checksum prettytable-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0fd04b170004fa2daccf418a7f8253aaf033c27760b5f225889024cf66d7ac2e"
-"checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
-"checksum proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)" = "77619697826f31a02ae974457af0b29b723e5619e113e9397b8b82c6bd253f09"
+"checksum proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)" = "38fddd23d98b2144d197c0eca5705632d4fe2667d14a6be5df8934f8d74f1978"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
-"checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
-"checksum quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c"
+"checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
 "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
-"checksum rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd"
+"checksum rand 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "dee497e66d8d76bf08ce20c8d36e16f93749ab0bf89975b4f8ae5cee660c2da2"
 "checksum rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c"
-"checksum rand 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ae9d223d52ae411a33cf7e54ec6034ec165df296ccd23533d671a28252b6f66a"
-"checksum rand_chacha 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "771b009e3a508cb67e8823dda454aaa5368c7bc1c16829fb77d3e980440dd34a"
+"checksum rand 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3906503e80ac6cbcacb2c2973fa8e473f24d7e2747c8c92bb230c2441cad96b5"
+"checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 "checksum rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1961a422c4d189dfb50ffa9320bf1f2a9bd54ecb92792fb9477f99a1045f3372"
 "checksum rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0905b6b7079ec73b314d4c748701f6931eb79fd97c668caa3f1899b22b32c6db"
 "checksum rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
 "checksum rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+"checksum rand_os 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f46fbd5550acf75b0c2730f5dd1873751daf9beb8f11b44027778fae50d7feca"
 "checksum rand_pcg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "086bd09a33c7044e56bb44d5bdde5a60e7f119a9e95b0775f545de759a32fe05"
-"checksum rand_xorshift 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "effa3fcaa47e18db002bdde6060944b6d2f9cfd8db471c30e873448ad9187be3"
-"checksum redox_syscall 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "a84bcd297b87a545980a2d25a0beb72a1f490c31f0a9fde52fca35bfbb1ceb70"
+"checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+"checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+"checksum redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)" = "423e376fffca3dfa06c9e9790a9ccd282fafb3cc6e6397d01dbf64f9bacc6b85"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37e7cbbd370869ce2e8dff25c7018702d10b21a20ef7135316f8daecd6c25b7f"
 "checksum regex-syntax 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4e47a2ed29da7a9e1960e1639e7a982e6edc6d49be308a3b02daf511504a16d1"
-"checksum rustc-demangle 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "01b90379b8664dd83460d59bdc5dd1fd3172b8913788db483ed1325171eab2f7"
+"checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
 "checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)" = "6fa52f19aee12441d5ad11c9a00459122bd8f98707cadf9778c540674f1935b6"
-"checksum serde_derive 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)" = "96a7f9496ac65a2db5929afa087b54f8fc5008dcfbe48a8874ed20049b0d6154"
-"checksum serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)" = "c37ccd6be3ed1fdf419ee848f7c758eb31b054d7cd3ae3600e3bae0adf569811"
+"checksum serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)" = "534b8b91a95e0f71bca3ed5824752d558da048d4248c91af873b63bd60519752"
+"checksum serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)" = "a915306b0f1ac5607797697148c223bedeaa36bcc2e28a01441cd638cc6567b4"
+"checksum serde_json 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)" = "574378d957d6dcdf1bbb5d562a15cbd5e644159432f84634b94e485267abbcc7"
 "checksum serde_yaml 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0887a8e097a69559b56aa2526bf7aff7c3048cf627dff781f0b56a6001534593"
 "checksum sha-1 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51b9d1f3b5de8a167ab06834a7c883bd197f2191e1dda1a22d9ccfeedbf9aded"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum structopt 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "670ad348dc73012fcf78c71f06f9d942232cdd4c859d4b6975e27836c3efc0c3"
 "checksum structopt-derive 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "ef98172b1a00b0bec738508d3726540edcbd186d50dfd326f2b1febbb3559f04"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
-"checksum syn 0.13.11 (registry+https://github.com/rust-lang/crates.io-index)" = "14f9bf6292f3a61d2c716723fdb789a41bbe104168e6f496dc6497e531ea1b9b"
 "checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
-"checksum syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9545a6a093a3f0bd59adb472700acc08cad3776f860f16a897dfce8c88721cbc"
+"checksum syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)" = "f92e629aa1d9c827b2bb8297046c1ccffc57c99b947a680d3ccff1f136a3bee9"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e6b677dd1e8214ea1ef4297f85dbcbed8e8cdddb561040cc998ca2551c37561"
@@ -1273,7 +1262,7 @@ dependencies = [
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
-"checksum time 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "847da467bf0db05882a9e2375934a8a55cffdc9db0d128af1518200260ba1f6c"
+"checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum try_from 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "923a7ee3e97dbfe8685261beb4511cc9620a1252405d02693d43169729570111"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum ucd-trie 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "71a9c5b1fe77426cf144cc30e49e955270f5086e31a6441dfa8b32efc09b9d77"
@@ -1286,7 +1275,6 @@ dependencies = [
 "checksum uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e1436e58182935dcd9ce0add9ea0b558e8a87befe01c1a301e6020aeb0876363"
 "checksum vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
-"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"

--- a/falconeri-worker/Cargo.toml
+++ b/falconeri-worker/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Eric Kidd <git@randomhacks.net>"]
 edition = "2018"
 
 [dependencies]
+crossbeam = "0.6.0"
 env_logger = "0.6"
 failure = "0.1.1"
 falconeri_common = { path = "../falconeri_common" }

--- a/falconeri-worker/src/main.rs
+++ b/falconeri-worker/src/main.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::pendantic)]
+
 use env_logger;
 use falconeri_common::{
     common_failures::display::DisplayCausesAndBacktraceExt, db, prefix::*,

--- a/falconeri-worker/src/main.rs
+++ b/falconeri-worker/src/main.rs
@@ -197,8 +197,10 @@ fn tee_output(
     to_console: &mut dyn Write,
     to_record: Arc<RwLock<dyn Write>>,
 ) -> Result<()> {
+    // Use a small buffer, because I/O performance doesn't matter for reading
+    // output to the user.
+    let mut buf = vec![0; 4 * 1024];
     loop {
-        let mut buf = vec![0; 4 * 1024];
         match from_child.read(&mut buf) {
             // No more output, so give up.
             Ok(0) => return Ok(()),

--- a/falconeri-worker/src/main.rs
+++ b/falconeri-worker/src/main.rs
@@ -1,3 +1,4 @@
+use crossbeam::{self, thread::Scope};
 use env_logger;
 use falconeri_common::{
     common_failures::display::DisplayCausesAndBacktraceExt, db, prelude::*,
@@ -5,7 +6,14 @@ use falconeri_common::{
 };
 use glob;
 use openssl_probe;
-use std::{env, fs, process, thread::sleep, time::Duration};
+use std::{
+    env, fs,
+    io::{self, prelude::*},
+    process,
+    sync::{Arc, RwLock},
+    thread::sleep,
+    time::Duration,
+};
 
 /// Instructions on how to use this program.
 const USAGE: &str = "Usage: falconeri-worker <job id>";
@@ -46,7 +54,14 @@ fn main() -> Result<()> {
 
         // Get the next datum and process it.
         if let Some((mut datum, files)) = job.reserve_next_datum(&conn)? {
-            let result = process_datum(&job, &datum, &files, &job.command);
+            // Process our datum, capturing its output.
+            let output = Arc::new(RwLock::new(vec![]));
+            let result =
+                process_datum(&job, &datum, &files, &job.command, output.clone());
+            let output_str = String::from_utf8_lossy(
+                &output.read().expect("background thread panic"),
+            )
+            .into_owned();
 
             // Reconnect to the database after processing the datum, in case our DB
             // connection has timed out or something horrible like that.
@@ -54,14 +69,14 @@ fn main() -> Result<()> {
 
             // Handle the processing results.
             match result {
-                Ok(()) => datum.mark_as_done(&conn)?,
+                Ok(()) => datum.mark_as_done(output_str.as_ref(), &conn)?,
                 Err(err) => {
                     error!(
                         "failed to process datum {}: {}",
                         datum.id,
                         err.display_causes_and_backtrace(),
                     );
-                    datum.mark_as_error(&err, &conn)?
+                    datum.mark_as_error(output_str.as_ref(), &err, &conn)?
                 }
             }
         } else {
@@ -91,6 +106,7 @@ fn process_datum(
     datum: &Datum,
     files: &[InputFile],
     cmd: &[String],
+    to_record: Arc<RwLock<dyn Write + Send + Sync>>,
 ) -> Result<()> {
     debug!("processing datum {}", datum.id);
 
@@ -103,22 +119,109 @@ fn process_datum(
         storage.sync_down(&file.uri, Path::new(&file.local_path))?;
     }
 
-    // Run our command.
-    if cmd.is_empty() {
-        return Err(format_err!("job {} command is empty", job.id));
-    }
-    let status = process::Command::new(&cmd[0])
-        .args(&cmd[1..])
-        .status()
-        .with_context(|_| format!("could not run {:?}", &cmd[0]))?;
-    if !status.success() {
-        return Err(format_err!("could not run {:?}", cmd));
-    }
+    // Set up a worker thread scope so that we can handle background I/O.
+    crossbeam::scope(|scope| -> Result<()> {
+        // Run our command.
+        if cmd.is_empty() {
+            return Err(format_err!("job {} command is empty", job.id));
+        }
+        let mut child = process::Command::new(&cmd[0])
+            .args(&cmd[1..])
+            .stdout(process::Stdio::piped())
+            .stderr(process::Stdio::piped())
+            .spawn()
+            .with_context(|_| format!("could not run {:?}", &cmd[0]))?;
 
-    // Finish up.
-    upload_outputs(job, datum).context("could not upload outputs")?;
-    reset_work_dirs()?;
+        // Listen on stdout.
+        tee_child(scope, &mut child, to_record)?;
+
+        let status = child
+            .wait()
+            .with_context(|_| format!("error running {:?}", &cmd[0]))?;
+        if !status.success() {
+            return Err(format_err!(
+                "command {:?} failed with status {}",
+                cmd,
+                status
+            ));
+        }
+
+        // Finish up.
+        upload_outputs(job, datum).context("could not upload outputs")?;
+        reset_work_dirs()?;
+        Ok(())
+    })
+    .expect("background panic")
+}
+
+/// Copy the stdout and stderr of `child` to either stdout or stderr,
+/// respectively, and write a copy to `to_record`.
+///
+/// This function will panic if `child` does not have a `stdout` or `stderr`.
+fn tee_child<'a>(
+    scope: &'a Scope,
+    child: &mut process::Child,
+    to_record: Arc<RwLock<dyn Write + Send + Sync>>,
+) -> Result<()> {
+    // Tee `stdout`.
+    let mut stdout = child
+        .stdout
+        .take()
+        .expect("child should always have a stdout");
+    let to_record_for_stdout = to_record.clone();
+    let stdout_handle = scope.spawn(move |_| {
+        tee_output(&mut stdout, &mut io::stdout(), to_record_for_stdout)
+    });
+
+    // Tee `stderr`.
+    let mut stderr = child
+        .stderr
+        .take()
+        .expect("child should always have a stderr");
+    let to_record_for_stderr = to_record.clone();
+    let stderr_handle = scope.spawn(move |_| {
+        tee_output(&mut stderr, &mut io::stderr(), to_record_for_stderr)
+    });
+
+    // Wait for our child process to close `stdout` and `stderr`, or at least
+    // for Rust to return 0-byte reads and writes.
+    stdout_handle.join().expect("background panic")?;
+    stderr_handle.join().expect("background panic")?;
+
     Ok(())
+}
+
+/// Copy output from `from_child` to `to_console` and `to_record`.
+fn tee_output(
+    from_child: &mut dyn Read,
+    to_console: &mut dyn Write,
+    to_record: Arc<RwLock<dyn Write>>,
+) -> Result<()> {
+    loop {
+        let mut buf = vec![0; 4 * 1024];
+        match from_child.read(&mut buf) {
+            // No more output, so give up.
+            Ok(0) => return Ok(()),
+            // We have output, so print it.
+            Ok(count) => {
+                let data = &buf[..count];
+                to_console.write(data).context("error writing to console")?;
+                to_record
+                    .write()
+                    .expect("background panic")
+                    .write(data)
+                    .context("error writing to record")?;
+            }
+            // Retry if reading was interrupted by kernal shenigans.
+            Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}
+            // An actual error occurred.
+            Err(e) => {
+                return Err(e)
+                    .context("error reading from child process")
+                    .map_err(|e| e.into());
+            }
+        }
+    }
 }
 
 /// Reset our working directories to a default, clean state.

--- a/falconeri-worker/src/main.rs
+++ b/falconeri-worker/src/main.rs
@@ -1,6 +1,6 @@
 use env_logger;
 use falconeri_common::{
-    common_failures::display::DisplayCausesAndBacktraceExt, db, prefix::*,
+    common_failures::display::DisplayCausesAndBacktraceExt, db, prelude::*,
     storage::CloudStorage,
 };
 use glob;

--- a/falconeri-worker/src/main.rs
+++ b/falconeri-worker/src/main.rs
@@ -1,5 +1,3 @@
-#![warn(clippy::pendantic)]
-
 use env_logger;
 use falconeri_common::{
     common_failures::display::DisplayCausesAndBacktraceExt, db, prefix::*,

--- a/falconeri/src/cmd/datum/describe.rs
+++ b/falconeri/src/cmd/datum/describe.rs
@@ -1,6 +1,6 @@
 //! The `datum describe` subcommand.
 
-use falconeri_common::{db, prefix::*};
+use falconeri_common::{db, prelude::*};
 
 use crate::description::render_description;
 

--- a/falconeri/src/cmd/datum/describe.txt.hbs
+++ b/falconeri/src/cmd/datum/describe.txt.hbs
@@ -8,12 +8,23 @@ Pod Name: {{datum.pod_name}}
 {{~ #if datum.node_name}}
 Node Name: {{datum.node_name}}
 {{~ /if}}
-{{~ #if datum.error_message}}
-
-Error Message: {{datum.error_message}}
-{{~ /if}}
 
 Input Files:
 {{~ #each input_files}}
 {{uri}}
 {{~ /each}}
+{{~ #if datum.error_message}}
+
+Error Message: {{datum.error_message}}
+{{~ #if datum.backtrace}}
+{{datum.backtrace ~}}
+{{~ /if}}
+{{~ /if}}
+{{~ #if datum.output}}
+
+Output:
+{{datum.output}}
+{{~ /if}}
+
+
+

--- a/falconeri/src/cmd/datum/mod.rs
+++ b/falconeri/src/cmd/datum/mod.rs
@@ -1,6 +1,6 @@
 //! The `datum` subcommand.
 
-use falconeri_common::prefix::*;
+use falconeri_common::prelude::*;
 use structopt::StructOpt;
 
 mod describe;

--- a/falconeri/src/cmd/db.rs
+++ b/falconeri/src/cmd/db.rs
@@ -1,6 +1,6 @@
 //! `db` subcommand for interaction with the database.
 
-use falconeri_common::{db, prefix::*};
+use falconeri_common::{db, prelude::*};
 use std::process;
 use structopt::StructOpt;
 

--- a/falconeri/src/cmd/deploy.rs
+++ b/falconeri/src/cmd/deploy.rs
@@ -3,7 +3,7 @@
 use base64;
 use falconeri_common::{
     kubernetes,
-    prefix::*,
+    prelude::*,
     rand::{distributions::Alphanumeric, rngs::EntropyRng, Rng},
 };
 use std::iter;

--- a/falconeri/src/cmd/deploy_manifest.yml.hbs
+++ b/falconeri/src/cmd/deploy_manifest.yml.hbs
@@ -40,12 +40,13 @@ spec:
       - name: falconeri-postgres
         image: postgres
         # Deliberately ridiculously high until we add a server, because we have
-        # lots of lightly-used connections.
-        args: ["postgres", "-c", "max_connections=500"]
+        # lots of lightly-used connections. The correct fix here is to write a
+        # falconeri daemon that talks to PostgreSQL for us.
+        args: ["postgres", "-c", "max_connections=2000"]
         resources:
           requests:
             cpu: 100m
-            memory: 500Mi
+            memory: 2Gi
         volumeMounts:
           # To prevent data loss, it's critically important to mount onto
           # `../data`. But we can only do that using `subPath` or PostgreSQL

--- a/falconeri/src/cmd/deploy_manifest.yml.hbs
+++ b/falconeri/src/cmd/deploy_manifest.yml.hbs
@@ -47,8 +47,12 @@ spec:
             cpu: 100m
             memory: 500Mi
         volumeMounts:
+          # To prevent data loss, it's critically important to mount onto
+          # `../data`. But we can only do that using `subPath` or PostgreSQL
+          # will error out.
           - name: pgdata
-            mountPath: /var/lib/postgresql
+            mountPath: /var/lib/postgresql/data
+            subPath: postgres
         env:
         - name: POSTGRES_PASSWORD
           valueFrom:

--- a/falconeri/src/cmd/job/describe.rs
+++ b/falconeri/src/cmd/job/describe.rs
@@ -1,6 +1,6 @@
 //! The `job describe` subcommand.
 
-use falconeri_common::{db, prefix::*};
+use falconeri_common::{db, prelude::*};
 
 use crate::description::render_description;
 

--- a/falconeri/src/cmd/job/job_manifest.yml.hbs
+++ b/falconeri/src/cmd/job/job_manifest.yml.hbs
@@ -19,6 +19,11 @@ spec:
 {{#if pipeline_spec.transform.service_account}}
       serviceAccountName: "{{pipeline_spec.transform.service_account}}"
 {{/if}}
+      tolerations:
+      - key: "fdy.io/falconeri"
+        operator: "Equal"
+        value: "worker"
+        effect: "NoExecute"
       nodeSelector:
 {{#each pipeline_spec.node_selector}}
         "{{@key}}": "{{this}}"

--- a/falconeri/src/cmd/job/list.rs
+++ b/falconeri/src/cmd/job/list.rs
@@ -1,6 +1,6 @@
 //! The `job list` subcommand.
 
-use falconeri_common::{db, prefix::*};
+use falconeri_common::{db, prelude::*};
 use prettytable::{cell, format::consts::FORMAT_CLEAN, row, Table};
 
 /// The `job list` subcommand.

--- a/falconeri/src/cmd/job/mod.rs
+++ b/falconeri/src/cmd/job/mod.rs
@@ -1,6 +1,6 @@
 //! The `job` subcommand.
 
-use falconeri_common::prefix::*;
+use falconeri_common::prelude::*;
 use serde_json;
 use structopt::StructOpt;
 

--- a/falconeri/src/cmd/job/mod.rs
+++ b/falconeri/src/cmd/job/mod.rs
@@ -10,7 +10,7 @@ mod describe;
 mod list;
 mod retry;
 mod run;
-mod schema;
+//mod schema;
 
 /// The `job` subcommand.
 #[derive(Debug, StructOpt)]
@@ -40,10 +40,11 @@ pub enum Opt {
         #[structopt(parse(from_os_str))]
         pipeline_json: PathBuf,
     },
-
-    /// Output a JSON schema for a falconeri job.
-    #[structopt(name = "schema")]
-    Schema,
+    // Disabled because `BsonSchema` doesn't handle recursive types.
+    //
+    // /// Output a JSON schema for a falconeri job.
+    // #[structopt(name = "schema")]
+    // Schema,
 }
 
 /// Run the `job` subcommand.
@@ -59,6 +60,6 @@ pub fn run(opt: &Opt) -> Result<()> {
                 .context("can't parse pipeline JSON file")?;
             run::run(&pipeline_spec)
         }
-        Opt::Schema => schema::run(),
+        //Opt::Schema => schema::run(),
     }
 }

--- a/falconeri/src/cmd/job/mod.rs
+++ b/falconeri/src/cmd/job/mod.rs
@@ -10,7 +10,9 @@ mod describe;
 mod list;
 mod retry;
 mod run;
-//mod schema;
+// Disabled because it's broken by recurive `"input"` types.
+//
+// mod schema;
 
 /// The `job` subcommand.
 #[derive(Debug, StructOpt)]
@@ -60,6 +62,8 @@ pub fn run(opt: &Opt) -> Result<()> {
                 .context("can't parse pipeline JSON file")?;
             run::run(&pipeline_spec)
         }
-        //Opt::Schema => schema::run(),
+        // Disabled because it's broken by recurive `"input"` types.
+        //
+        // Opt::Schema => schema::run(),
     }
 }

--- a/falconeri/src/cmd/job/retry.rs
+++ b/falconeri/src/cmd/job/retry.rs
@@ -1,6 +1,6 @@
 //! The `job retry` subcommand.
 
-use falconeri_common::{cast, db, diesel::Connection, prefix::*};
+use falconeri_common::{cast, db, diesel::Connection, prelude::*};
 use serde_json;
 use std::cmp::min;
 

--- a/falconeri/src/cmd/job/retry.rs
+++ b/falconeri/src/cmd/job/retry.rs
@@ -31,6 +31,7 @@ pub fn run(job_name: &str) -> Result<()> {
         // Create a new job record.
         let job_name = unique_kubernetes_job_name(&pipeline_spec.pipeline.name);
         let new_job = NewJob {
+            id: Uuid::new_v4(),
             pipeline_spec: job.pipeline_spec.clone(),
             job_name,
             command: job.command.clone(),

--- a/falconeri/src/cmd/job/run.rs
+++ b/falconeri/src/cmd/job/run.rs
@@ -1,56 +1,45 @@
 //! The `job run` subcommand.
 
-use falconeri_common::{db, kubernetes, prefix::*, storage::CloudStorage};
+use falconeri_common::{db, kubernetes, prefix::*};
 use serde_json::json;
 
+use crate::inputs::input_to_datums;
 use crate::manifest::render_manifest;
 use crate::pipeline::*;
 
 /// The `job run` subcommand.
 pub fn run(pipeline_spec: &PipelineSpec) -> Result<()> {
-    match &pipeline_spec.input {
-        Input::Atom { uri, repo, glob } => {
-            // Check to make sure we're using a supported glob mode.
-            if *glob != Glob::TopLevelDirectoryEntries {
-                return Err(format_err!("Glob {:?} not yet supported", glob));
-            }
+    // Build our job.
+    let job_id = Uuid::new_v4();
+    let job_name = unique_kubernetes_job_name(&pipeline_spec.pipeline.name);
+    let new_job = NewJob {
+        id: job_id,
+        pipeline_spec: json!(pipeline_spec),
+        job_name,
+        command: pipeline_spec.transform.cmd.clone(),
+        egress_uri: pipeline_spec.egress.uri.clone(),
+    };
 
-            // Figure out what files to process
-            let storage =
-                CloudStorage::for_uri(&uri, &pipeline_spec.transform.secrets)?;
-            let paths = storage.list(uri)?;
+    // Get our datums and input files.
+    let (new_datums, new_input_files) = input_to_datums(
+        &pipeline_spec.transform.secrets,
+        job_id,
+        &pipeline_spec.input,
+    )?;
 
-            // Make sure we have no nested directories, which we don't handle
-            // correctly for "/*" yet.
-            let mut base = uri.to_owned();
-            if !base.ends_with('/') {
-                base.push_str("/");
-            }
-            for path in &paths {
-                // These assertions should always be true because of how
-                // `storage.list` is supposed to work.
-                assert!(path.len() > base.len());
-                assert_eq!(path[..base.len()], base);
+    // Insert everthing into the database.
+    let conn = db::connect(db::ConnectVia::Proxy)?;
+    let job = conn.transaction(|| -> Result<Job> {
+        let job = new_job.insert(&conn)?;
+        NewDatum::insert_all(&new_datums, &conn)?;
+        NewInputFile::insert_all(&new_input_files, &conn)?;
+        Ok(job)
+    })?;
 
-                // Strip base and look for a remaining '/'.
-                if path[base.len()..].find('/').is_some() {
-                    return Err(format_err!(
-                        "we cannot handle directory inputs yet: {:?}",
-                        path,
-                    ));
-                }
-            }
-
-            // Add our job to the database, and launch our batch job on the
-            // cluster.
-            let job = add_job_to_database(pipeline_spec, &paths, repo)?;
-            start_batch_job(pipeline_spec, &job)?;
-            println!("{}", job.job_name);
-
-            Ok(())
-        }
-        _ => Err(format_err!("cannot handle input")),
-    }
+    // Launch our batch job on the cluster.
+    start_batch_job(pipeline_spec, &job)?;
+    println!("{}", job.job_name);
+    Ok(())
 }
 
 /// Generate a unique name for our job. To keep Kubernetes happy, this
@@ -61,72 +50,6 @@ pub fn unique_kubernetes_job_name(pipeline_name: &str) -> String {
     format!("{}-{}", pipeline_name, tag)
         .replace("_", "-")
         .to_lowercase()
-}
-
-/// Register a new job in the database.
-fn add_job_to_database(
-    pipeline_spec: &PipelineSpec,
-    inputs: &[String],
-    repo: &str,
-) -> Result<Job> {
-    let conn = db::connect(db::ConnectVia::Proxy)?;
-    let job = conn.transaction(|| -> Result<Job> {
-        // Create our new job.
-        let job_name = unique_kubernetes_job_name(&pipeline_spec.pipeline.name);
-        let new_job = NewJob {
-            pipeline_spec: json!(pipeline_spec),
-            job_name,
-            command: pipeline_spec.transform.cmd.clone(),
-            egress_uri: pipeline_spec.egress.uri.clone(),
-        };
-        let job = new_job.insert(&conn)?;
-
-        // Create a datum for each input file. For now, we only handle the
-        // trivial case of one file per datum.
-        let mut datums = vec![];
-        let mut input_files = vec![];
-        for input in inputs {
-            let datum_id = Uuid::new_v4();
-            datums.push(NewDatum {
-                id: datum_id,
-                job_id: job.id,
-            });
-
-            input_files.push(NewInputFile {
-                datum_id,
-                uri: input.to_owned(),
-                local_path: uri_to_local_path(input, repo)?,
-                job_id: job.id,
-            });
-        }
-        NewDatum::insert_all(&datums, &conn)?;
-        NewInputFile::insert_all(&input_files, &conn)?;
-        Ok(job)
-    })?;
-    Ok(job)
-}
-
-/// Given a URI and a repo name, construct a local path starting with "/pfs"
-/// pointing to where we should download the file.
-///
-/// TODO: This will need to get fancier if we actually implement globs
-/// correctly.
-fn uri_to_local_path(uri: &str, repo: &str) -> Result<String> {
-    let pos = uri
-        .rfind('/')
-        .ok_or_else(|| format_err!("No '/' in {:?}", uri))?;
-    let basename = &uri[pos..];
-    if basename.is_empty() {
-        Err(format_err!("{:?} ends with '/'", uri))
-    } else {
-        Ok(format!("/pfs/{}{}", repo, basename))
-    }
-}
-
-#[test]
-fn uri_to_local_path_works() {
-    let path = uri_to_local_path("gs://bucket/path/data1.csv", "myrepo").unwrap();
-    assert_eq!(path, "/pfs/myrepo/data1.csv");
 }
 
 /// The manifest to use to run a job.

--- a/falconeri/src/cmd/job/run.rs
+++ b/falconeri/src/cmd/job/run.rs
@@ -1,6 +1,6 @@
 //! The `job run` subcommand.
 
-use falconeri_common::{db, kubernetes, prefix::*};
+use falconeri_common::{db, kubernetes, prelude::*};
 use serde_json::json;
 
 use crate::inputs::input_to_datums;

--- a/falconeri/src/cmd/job/run.rs
+++ b/falconeri/src/cmd/job/run.rs
@@ -11,8 +11,8 @@ pub fn run(pipeline_spec: &PipelineSpec) -> Result<()> {
     match &pipeline_spec.input {
         Input::Atom { uri, repo, glob } => {
             // Check to make sure we're using a supported glob mode.
-            if glob != "/*" {
-                return Err(format_err!("Glob {} not yet supported", glob));
+            if *glob != Glob::TopLevelDirectoryEntries {
+                return Err(format_err!("Glob {:?} not yet supported", glob));
             }
 
             // Figure out what files to process
@@ -49,6 +49,7 @@ pub fn run(pipeline_spec: &PipelineSpec) -> Result<()> {
 
             Ok(())
         }
+        _ => Err(format_err!("cannot handle input")),
     }
 }
 

--- a/falconeri/src/cmd/job/schema.rs
+++ b/falconeri/src/cmd/job/schema.rs
@@ -1,6 +1,6 @@
 //! The `job schema` subcommand.
 
-use falconeri_common::prefix::*;
+use falconeri_common::prelude::*;
 use magnet_schema::BsonSchema;
 use serde_json;
 use std::io::stdout;

--- a/falconeri/src/cmd/migrate.rs
+++ b/falconeri/src/cmd/migrate.rs
@@ -1,6 +1,6 @@
 //! The `migrate` subcommand.
 
-use falconeri_common::{db, prefix::*};
+use falconeri_common::{db, prelude::*};
 
 /// Run the `migrate` subcommand.
 pub fn run() -> Result<()> {

--- a/falconeri/src/cmd/proxy.rs
+++ b/falconeri/src/cmd/proxy.rs
@@ -1,6 +1,6 @@
 //! The `proxy` subcommand.
 
-use falconeri_common::{kubernetes, prefix::*};
+use falconeri_common::{kubernetes, prelude::*};
 
 /// Run our proxy.
 pub fn run() -> Result<()> {

--- a/falconeri/src/description.rs
+++ b/falconeri/src/description.rs
@@ -1,6 +1,6 @@
 //! Human-readable descriptions of an object.
 
-use falconeri_common::prefix::*;
+use falconeri_common::prelude::*;
 use handlebars::Handlebars;
 
 /// Render the specified textual description, filling in the supplied values

--- a/falconeri/src/inputs.rs
+++ b/falconeri/src/inputs.rs
@@ -1,0 +1,222 @@
+//! Convert JSON `"input"` clauses to datums which will be assigned to workers.
+
+use falconeri_common::{
+    models::{NewDatum, NewInputFile},
+    prefix::*,
+    secret::Secret,
+    storage::CloudStorage,
+};
+
+use crate::pipeline::{Glob, Input};
+
+/// (Local helper type.) This is essentially just a `NewDatum` and a
+/// `Vec<NewInputFile>`, but in a more convenient format that works better with
+/// the algorithm in this file, so we don't need to carry around UUIDs
+/// everywhere.
+#[derive(Clone, Debug)]
+struct DatumData {
+    input_files: Vec<InputFileData>,
+}
+
+impl DatumData {
+    /// Convert this into an actual `NewDatum` and a `Vec<NewInputFile>`.
+    fn into_new_datum_and_input_files(
+        self,
+        job_id: Uuid,
+    ) -> (NewDatum, Vec<NewInputFile>) {
+        let datum_id = Uuid::new_v4();
+        let datum = NewDatum {
+            id: datum_id,
+            job_id,
+        };
+        let input_files = self
+            .input_files
+            .into_iter()
+            .map(|f| f.into_new_input_file(job_id, datum_id))
+            .collect();
+        (datum, input_files)
+    }
+}
+
+/// (Local helper type.) This is essentially a `NewInputFile`, but in a more
+/// convenient format.
+#[derive(Clone, Debug)]
+struct InputFileData {
+    uri: String,
+    local_path: String,
+}
+
+impl InputFileData {
+    /// Convert this into an actual `NewInputFile`.
+    fn into_new_input_file(self, job_id: Uuid, datum_id: Uuid) -> NewInputFile {
+        NewInputFile {
+            job_id,
+            datum_id,
+            uri: self.uri,
+            local_path: self.local_path,
+        }
+    }
+}
+
+/// Given an `Input` from a JSON pipeline spec, convert to an actual set of
+/// "datums" (work chunks) to be assigned to a worker.
+///
+/// Returns the datums and associated input files in a form well-suited to bulk
+/// database insert.
+pub fn input_to_datums(
+    secrets: &[Secret],
+    job_id: Uuid,
+    input: &Input,
+) -> Result<(Vec<NewDatum>, Vec<NewInputFile>)> {
+    let mut all_datums = vec![];
+    let mut all_input_files = vec![];
+    for datum_data in input_to_datums_helper(secrets, input)? {
+        let (datum, input_files) = datum_data.into_new_datum_and_input_files(job_id);
+        all_datums.push(datum);
+        all_input_files.extend(input_files);
+    }
+    Ok((all_datums, all_input_files))
+}
+
+/// Given an `Input` from a JSON pipeline spec, convert to an actual set of
+/// "datums" (work chunks) to be assigned to a worker.
+///
+/// This is the internal helper version of `input_to_datums` that works on the
+/// simpler `DatumData` instead of database-ready `NewDatum` records.
+fn input_to_datums_helper(
+    secrets: &[Secret],
+    input: &Input,
+) -> Result<Vec<DatumData>> {
+    match input {
+        Input::Atom { uri, repo, glob } => {
+            atom_to_datums_helper(secrets, uri, repo, *glob)
+        }
+        Input::Cross(inputs) => cross_to_datums_helper(secrets, inputs),
+        Input::Union(inputs) => {
+            // Merge all our inputs. We could do this cleverly using `flat_map`
+            // and `collect` to manage the errors, but it's clearer with a `for`
+            // loop.
+            let mut datums = vec![];
+            for child in inputs {
+                datums.extend(input_to_datums_helper(secrets, child)?);
+            }
+            Ok(datums)
+        }
+    }
+}
+
+/// Convert a single `Input::Atom` to a list of datums.
+fn atom_to_datums_helper(
+    secrets: &[Secret],
+    uri: &str,
+    repo: &str,
+    glob: Glob,
+) -> Result<Vec<DatumData>> {
+    // Normalize our URI to always include a slash, because repositories must
+    // currently be directories.
+    let mut base = uri.to_owned();
+    if !base.ends_with('/') {
+        base.push_str("/");
+    }
+
+    // Figure out what files to process. We do this for _both_
+    // `Glob::TopLevelDirectoryEntries` and `Glob::WholeRepo`, because we want
+    // to verify that we can actually list the contents of a `Glob::WholeRepo`
+    // _before_ spinning up a big cluster job.
+    let storage = CloudStorage::for_uri(&uri, secrets)?;
+    let paths = storage.list(uri)?;
+
+    match glob {
+        // Our input file is just the entire repo, as a directory.
+        Glob::WholeRepo => Ok(vec![DatumData {
+            input_files: vec![InputFileData {
+                uri: base,
+                local_path: format!("/pfs/{}", repo),
+            }],
+        }]),
+
+        // Each top-level file or directory in `base` should be translated into
+        // a separate datum.
+        Glob::TopLevelDirectoryEntries => {
+            let mut datums = vec![];
+            for path in paths {
+                let local_path = uri_to_local_path(&base, repo)?;
+                datums.push(DatumData {
+                    input_files: vec![InputFileData {
+                        uri: path,
+                        local_path,
+                    }],
+                });
+            }
+            Ok(datums)
+        }
+    }
+}
+
+/// Convert a cross product into a list of datums.
+///
+/// SECURITY: This assumes it runs on reasonably trusted and plausible inputs.
+/// You can cause a denial-of-service by calculating the cross product of
+/// enormous repos, or by passing in so many repos that the stack overflows. But
+/// since our input comes from a local user, this is fine for now.
+fn cross_to_datums_helper(
+    secrets: &[Secret],
+    inputs: &[Input],
+) -> Result<Vec<DatumData>> {
+    match inputs.len() {
+        // Base cases.
+        0 => Ok(vec![]),
+        1 => input_to_datums_helper(secrets, &inputs[0]),
+
+        // Recursive case.
+        n => {
+            // Recursively calculate the cross product of all but our last input.
+            let datums_0 = cross_to_datums_helper(secrets, &inputs[0..n - 1])?;
+
+            // Process our last input.
+            let datums_1 = input_to_datums_helper(secrets, &inputs[n - 1])?;
+
+            // Build our cross product between the recursive `datums_0` and our
+            // local `datums_1`.
+            let mut output = vec![];
+            for datum_0 in &datums_0 {
+                for datum_1 in &datums_1 {
+                    let input_files_0 = &datum_0.input_files;
+                    let input_files_1 = &datum_1.input_files;
+                    let len_0 = input_files_0.len();
+                    let len_1 = input_files_1.len();
+                    let mut combined = Vec::with_capacity(len_0 + len_1);
+                    combined.extend(input_files_0.iter().cloned());
+                    combined.extend(input_files_1.iter().cloned());
+                    output.push(DatumData {
+                        input_files: combined,
+                    })
+                }
+            }
+            Ok(output)
+        }
+    }
+}
+
+/// Given a URI and a repo name, construct a local path starting with "/pfs"
+/// pointing to where we should download the file.
+///
+/// TODO: This will need to get fancier if we actually implement globs
+/// correctly.
+fn uri_to_local_path(uri: &str, repo: &str) -> Result<String> {
+    let pos = uri
+        .rfind('/')
+        .ok_or_else(|| format_err!("No '/' in {:?}", uri))?;
+    let basename = &uri[pos..];
+    if basename.is_empty() {
+        Err(format_err!("{:?} ends with '/'", uri))
+    } else {
+        Ok(format!("/pfs/{}{}", repo, basename))
+    }
+}
+
+#[test]
+fn uri_to_local_path_works() {
+    let path = uri_to_local_path("gs://bucket/path/data1.csv", "myrepo").unwrap();
+    assert_eq!(path, "/pfs/myrepo/data1.csv");
+}

--- a/falconeri/src/inputs.rs
+++ b/falconeri/src/inputs.rs
@@ -124,7 +124,7 @@ fn atom_to_datums_helper(
     // to verify that we can actually list the contents of a `Glob::WholeRepo`
     // _before_ spinning up a big cluster job.
     let storage = CloudStorage::for_uri(&uri, secrets)?;
-    let paths = storage.list(uri)?;
+    let file_uris = storage.list(uri)?;
 
     match glob {
         // Our input file is just the entire repo, as a directory.
@@ -139,11 +139,11 @@ fn atom_to_datums_helper(
         // a separate datum.
         Glob::TopLevelDirectoryEntries => {
             let mut datums = vec![];
-            for path in paths {
-                let local_path = uri_to_local_path(&base, repo)?;
+            for file_uri in file_uris {
+                let local_path = uri_to_local_path(&file_uri, repo)?;
                 datums.push(DatumData {
                     input_files: vec![InputFileData {
-                        uri: path,
+                        uri: file_uri,
                         local_path,
                     }],
                 });

--- a/falconeri/src/inputs.rs
+++ b/falconeri/src/inputs.rs
@@ -2,7 +2,7 @@
 
 use falconeri_common::{
     models::{NewDatum, NewInputFile},
-    prefix::*,
+    prelude::*,
     secret::Secret,
     storage::CloudStorage,
 };

--- a/falconeri/src/main.rs
+++ b/falconeri/src/main.rs
@@ -1,5 +1,3 @@
-#![warn(clippy::pendantic)]
-
 use env_logger;
 use falconeri_common::prefix::*;
 use openssl_probe;

--- a/falconeri/src/main.rs
+++ b/falconeri/src/main.rs
@@ -1,4 +1,5 @@
-use base64;
+#![warn(clippy::pendantic)]
+
 use env_logger;
 use falconeri_common::prefix::*;
 use openssl_probe;

--- a/falconeri/src/main.rs
+++ b/falconeri/src/main.rs
@@ -5,6 +5,7 @@ use structopt::StructOpt;
 
 mod cmd;
 mod description;
+mod inputs;
 mod manifest;
 mod pipeline;
 

--- a/falconeri/src/main.rs
+++ b/falconeri/src/main.rs
@@ -1,5 +1,5 @@
 use env_logger;
-use falconeri_common::prefix::*;
+use falconeri_common::prelude::*;
 use openssl_probe;
 use structopt::StructOpt;
 

--- a/falconeri/src/manifest.rs
+++ b/falconeri/src/manifest.rs
@@ -1,6 +1,6 @@
 //! Tools for manipulating Kubernetes manifests.
 
-use falconeri_common::prefix::*;
+use falconeri_common::prelude::*;
 use handlebars::Handlebars;
 
 /// Render the specified YAML manifest, filling in the supplied values

--- a/falconeri/src/pipeline.rs
+++ b/falconeri/src/pipeline.rs
@@ -124,7 +124,6 @@ pub struct Egress {
     pub uri: String,
 }
 
-
 #[test]
 fn parse_nested_inputs() {
     let json = r#"

--- a/falconeri/src/pipeline.rs
+++ b/falconeri/src/pipeline.rs
@@ -5,7 +5,7 @@
 //! [pipespec]: http://docs.pachyderm.io/en/latest/reference/pipeline_spec.html
 
 use bson::{bson, doc};
-use falconeri_common::{prefix::*, secret::Secret};
+use falconeri_common::{prelude::*, secret::Secret};
 use magnet_derive::BsonSchema;
 
 /// Represents a pipeline *.json file.

--- a/falconeri_common/migrations/2019-01-23-214049_add_datum_backtrace_and_output/down.sql
+++ b/falconeri_common/migrations/2019-01-23-214049_add_datum_backtrace_and_output/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE datums DROP COLUMN output;
+ALTER TABLE datums DROP COLUMN backtrace;

--- a/falconeri_common/migrations/2019-01-23-214049_add_datum_backtrace_and_output/up.sql
+++ b/falconeri_common/migrations/2019-01-23-214049_add_datum_backtrace_and_output/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE datums ADD COLUMN backtrace TEXT;
+ALTER TABLE datums ADD COLUMN output text;

--- a/falconeri_common/src/db.rs
+++ b/falconeri_common/src/db.rs
@@ -4,7 +4,7 @@ use backoff::{self, ExponentialBackoff, Operation};
 use std::{env, fs::read_to_string, io, result};
 
 use crate::kubernetes::{base64_encoded_secret_string, kubectl_secret};
-use crate::prefix::*;
+use crate::prelude::*;
 
 /// Embed our migrations directly into the executable. We use a
 /// submodule so we can configure warnings.

--- a/falconeri_common/src/kubernetes.rs
+++ b/falconeri_common/src/kubernetes.rs
@@ -9,7 +9,7 @@ use std::{
     process::{Command, Stdio},
 };
 
-use crate::prefix::*;
+use crate::prelude::*;
 
 /// Run `kubectl`, passing any output through to the console.
 pub fn kubectl(args: &[&str]) -> Result<()> {

--- a/falconeri_common/src/lib.rs
+++ b/falconeri_common/src/lib.rs
@@ -1,6 +1,6 @@
 //! Code shared between various Falconeri tools.
 
-#![warn(missing_docs)]
+#![warn(missing_docs, clippy::pendantic)]
 // Silence diesel warnings: https://github.com/diesel-rs/diesel/pull/1787
 #![allow(proc_macro_derive_resolution_fallback)]
 
@@ -11,8 +11,6 @@ pub extern crate diesel;
 #[macro_use]
 pub extern crate diesel_migrations;
 
-use backoff;
-use base64;
 pub use cast;
 pub use chrono;
 pub use common_failures;

--- a/falconeri_common/src/lib.rs
+++ b/falconeri_common/src/lib.rs
@@ -25,7 +25,7 @@ pub mod secret;
 pub mod storage;
 
 /// Common imports used by many modules.
-pub mod prefix {
+pub mod prelude {
     pub use chrono::{NaiveDateTime, Utc};
     pub use diesel::{self, prelude::*, PgConnection};
     pub use failure::{format_err, ResultExt};

--- a/falconeri_common/src/lib.rs
+++ b/falconeri_common/src/lib.rs
@@ -1,6 +1,6 @@
 //! Code shared between various Falconeri tools.
 
-#![warn(missing_docs, clippy::pendantic)]
+#![warn(missing_docs)]
 // Silence diesel warnings: https://github.com/diesel-rs/diesel/pull/1787
 #![allow(proc_macro_derive_resolution_fallback)]
 

--- a/falconeri_common/src/models/datum.rs
+++ b/falconeri_common/src/models/datum.rs
@@ -1,6 +1,6 @@
 use common_failures::display::DisplayCausesAndBacktraceExt;
 
-use crate::prefix::*;
+use crate::prelude::*;
 use crate::schema::*;
 
 /// A single chunk of work, consisting of one or more files.

--- a/falconeri_common/src/models/datum.rs
+++ b/falconeri_common/src/models/datum.rs
@@ -23,6 +23,10 @@ pub struct Datum {
     pub node_name: Option<String>,
     /// The Kubernetes pod which is running / ran this job.
     pub pod_name: Option<String>,
+    /// The backtrace associated with `error_message`, if any.
+    pub backtrace: Option<String>,
+    /// Combined stdout and stderr of the code which processed the datum.
+    pub output: Option<String>,
 }
 
 impl Datum {
@@ -43,9 +47,9 @@ impl Datum {
     }
 
     /// Mark this datum as having been successfully processed.
-    pub fn mark_as_done(&mut self, conn: &PgConnection) -> Result<()> {
+    pub fn mark_as_done(&mut self, output: &str, conn: &PgConnection) -> Result<()> {
         *self = diesel::update(datums::table.filter(datums::id.eq(&self.id)))
-            .set(datums::status.eq(&Status::Done))
+            .set((datums::status.eq(&Status::Done), datums::output.eq(output)))
             .get_result(conn)
             .context("can't mark datum as done")?;
         Ok(())
@@ -54,14 +58,18 @@ impl Datum {
     /// Mark this datum as having been unsuccessfully processed.
     pub fn mark_as_error(
         &mut self,
-        error_message: &dyn DisplayCausesAndBacktraceExt,
+        output: &str,
+        err: &Error,
         conn: &PgConnection,
     ) -> Result<()> {
+        let error_message = format!("{}", err.display_causes_without_backtrace());
+        let backtrace = format!("{}", err.backtrace());
         *self = diesel::update(datums::table.filter(datums::id.eq(&self.id)))
             .set((
                 datums::status.eq(&Status::Error),
-                datums::error_message
-                    .eq(&format!("{}", error_message.display_causes_and_backtrace(),)),
+                datums::output.eq(output),
+                datums::error_message.eq(&error_message),
+                datums::backtrace.eq(&backtrace),
             ))
             .get_result(conn)
             .context("can't mark datum as having failed")?;
@@ -80,6 +88,8 @@ impl Datum {
             error_message: None,
             node_name: None,
             pod_name: None,
+            backtrace: None,
+            output: None,
         }
     }
 }

--- a/falconeri_common/src/models/input_file.rs
+++ b/falconeri_common/src/models/input_file.rs
@@ -1,4 +1,4 @@
-use crate::prefix::*;
+use crate::prelude::*;
 use crate::schema::*;
 
 /// An input file which needs to be downloaded to the worker container.

--- a/falconeri_common/src/models/job.rs
+++ b/falconeri_common/src/models/job.rs
@@ -228,6 +228,8 @@ impl Job {
 #[derive(Debug, Insertable)]
 #[table_name = "jobs"]
 pub struct NewJob {
+    /// The unique ID for this job.
+    pub id: Uuid,
     /// A copy of our original pipeline spec (just for debugging).
     pub pipeline_spec: serde_json::Value,
     /// The Kubenetes `Job` name for this job.

--- a/falconeri_common/src/models/job.rs
+++ b/falconeri_common/src/models/job.rs
@@ -3,7 +3,7 @@ use diesel::dsl;
 use serde_json;
 use std::env;
 
-use crate::prefix::*;
+use crate::prelude::*;
 use crate::schema::*;
 
 /// A distributed data processing job.

--- a/falconeri_common/src/models/mod.rs
+++ b/falconeri_common/src/models/mod.rs
@@ -2,7 +2,7 @@
 
 use diesel::{deserialize, pg::Pg, serialize};
 
-use crate::prefix::*;
+use crate::prelude::*;
 
 mod datum;
 mod input_file;

--- a/falconeri_common/src/models/output_file.rs
+++ b/falconeri_common/src/models/output_file.rs
@@ -1,4 +1,4 @@
-use crate::prefix::*;
+use crate::prelude::*;
 use crate::schema::*;
 
 /// An output file uploaded from a worker.

--- a/falconeri_common/src/schema.rs
+++ b/falconeri_common/src/schema.rs
@@ -1,10 +1,6 @@
-#![allow(missing_docs, unused_imports)]
-
-use crate::models::sql_types::Status;
-use diesel::sql_types::*;
-
 table! {
-    use super::*;
+    use diesel::sql_types::*;
+    use crate::models::sql_types::Status;
 
     datums (id) {
         id -> Uuid,
@@ -15,11 +11,13 @@ table! {
         error_message -> Nullable<Text>,
         node_name -> Nullable<Text>,
         pod_name -> Nullable<Text>,
+        backtrace -> Nullable<Text>,
+        output -> Nullable<Text>,
     }
 }
 
 table! {
-    use super::*;
+    use diesel::sql_types::*;
 
     input_files (id) {
         id -> Uuid,
@@ -32,7 +30,8 @@ table! {
 }
 
 table! {
-    use super::*;
+    use diesel::sql_types::*;
+    use crate::models::sql_types::Status;
 
     jobs (id) {
         id -> Uuid,
@@ -47,7 +46,8 @@ table! {
 }
 
 table! {
-    use super::*;
+    use diesel::sql_types::*;
+    use crate::models::sql_types::Status;
 
     output_files (id) {
         id -> Uuid,

--- a/falconeri_common/src/secret.rs
+++ b/falconeri_common/src/secret.rs
@@ -3,7 +3,7 @@
 use bson::{bson, doc};
 use magnet_derive::BsonSchema;
 
-use crate::prefix::*;
+use crate::prelude::*;
 
 /// A Kubernetes-managed secret used to access some resource, and how we should
 /// map it into a container. Kubernetes secrets contain key-value pairs.

--- a/falconeri_common/src/storage/gs.rs
+++ b/falconeri_common/src/storage/gs.rs
@@ -62,7 +62,7 @@ impl CloudStorage for GoogleCloudStorage {
                 return Err(format_err!("could not download {:?}: {}", uri, status));
             }
         } else {
-            // We have a file.
+            // We have a file. We can't use `gsutil rsync` for this case.
             trace!("downloading {} to {}", uri, local_path.display());
             if let Some(parent) = local_path.parent() {
                 fs::create_dir_all(parent)

--- a/falconeri_common/src/storage/gs.rs
+++ b/falconeri_common/src/storage/gs.rs
@@ -3,7 +3,7 @@
 use std::{collections::HashSet, io::BufRead, process};
 
 use super::CloudStorage;
-use crate::prefix::*;
+use crate::prelude::*;
 use crate::secret::Secret;
 
 /// Backend for talking to Google Cloud Storage, currently based on `gsutil`.

--- a/falconeri_common/src/storage/gs.rs
+++ b/falconeri_common/src/storage/gs.rs
@@ -1,6 +1,6 @@
 //! Support for Google Cloud Storage.
 
-use std::{collections::HashSet, io::BufRead, process};
+use std::{collections::HashSet, fs, io::BufRead, process};
 
 use super::CloudStorage;
 use crate::prelude::*;
@@ -42,15 +42,41 @@ impl CloudStorage for GoogleCloudStorage {
     }
 
     fn sync_down(&self, uri: &str, local_path: &Path) -> Result<()> {
-        trace!("downloading {} to {}", uri, local_path.display());
-        let status = process::Command::new("gsutil")
-            .args(&["-m", "cp", "-r"])
-            .arg(uri)
-            .arg(local_path)
-            .status()
-            .context("could not run gsutil")?;
-        if !status.success() {
-            return Err(format_err!("could not download {:?}: {}", uri, status));
+        if uri.ends_with('/') {
+            // We have a directory. If our source URI ends in `/`, so should our
+            // `local_path`, since we generate these ourselves.
+            assert!(local_path
+                .to_str()
+                .expect("path should be UTF-8")
+                .ends_with('/'));
+            trace!("syncing {} to {}", uri, local_path.display());
+            fs::create_dir_all(local_path)
+                .context("cannot create local download directory")?;
+            let status = process::Command::new("gsutil")
+                .args(&["-m", "rsync"])
+                .arg(uri)
+                .arg(local_path)
+                .status()
+                .context("could not run gsutil rsync")?;
+            if !status.success() {
+                return Err(format_err!("could not download {:?}: {}", uri, status));
+            }
+        } else {
+            // We have a file.
+            trace!("downloading {} to {}", uri, local_path.display());
+            if let Some(parent) = local_path.parent() {
+                fs::create_dir_all(parent)
+                    .context("cannot create local download directory")?;
+            }
+            let status = process::Command::new("gsutil")
+                .args(&["-m", "cp", "-r"])
+                .arg(uri)
+                .arg(local_path)
+                .status()
+                .context("could not run gsutil cp")?;
+            if !status.success() {
+                return Err(format_err!("could not download {:?}: {}", uri, status));
+            }
         }
         Ok(())
     }

--- a/falconeri_common/src/storage/mod.rs
+++ b/falconeri_common/src/storage/mod.rs
@@ -1,6 +1,6 @@
 //! Cloud storage backends.
 
-use crate::prefix::*;
+use crate::prelude::*;
 use crate::secret::Secret;
 
 pub mod gs;

--- a/falconeri_common/src/storage/mod.rs
+++ b/falconeri_common/src/storage/mod.rs
@@ -16,6 +16,11 @@ pub trait CloudStorage {
     /// existing destination files. The contents of `uri` should be exactly
     /// represented in `local_path`, without the trailing subdirectory name
     /// being inserted—this is a straight directory-to-directory sync.
+    ///
+    /// To sync down a file, neither `uri` nor `local_path` should end in `/`.
+    /// To sync down a directory, _both_ `uri` and `local_path` must end in `/`.
+    /// Any other combination is allowed to fail or panic at the discretion of
+    /// the implementation.
     fn sync_down(&self, uri: &str, local_path: &Path) -> Result<()>;
 
     /// Synchronize `local_path` to `uri` recursively. Does not delete any

--- a/falconeri_common/src/storage/s3.rs
+++ b/falconeri_common/src/storage/s3.rs
@@ -8,7 +8,7 @@ use std::process;
 
 use super::CloudStorage;
 use crate::kubernetes::{base64_encoded_secret_string, kubectl_secret};
-use crate::prefix::*;
+use crate::prelude::*;
 use crate::secret::Secret;
 
 /// An S3 secret fetched from Kubernetes. This can be fetched using

--- a/falconeri_common/src/storage/s3.rs
+++ b/falconeri_common/src/storage/s3.rs
@@ -111,8 +111,6 @@ impl CloudStorage for S3Storage {
         Ok(s3_output
             .contents
             .into_iter()
-            // Only include files.
-            .filter(|obj| !obj.key.ends_with('/'))
             // Convert to URLs.
             .map(|obj| format!("s3://{}/{}", bucket, obj.key))
             .collect::<Vec<_>>())
@@ -135,7 +133,7 @@ impl CloudStorage for S3Storage {
             .arg(uri)
             .arg(local_path)
             .status()
-            .context("could not run gsutil")?;
+            .context("could not run aws s3")?;
         if !status.success() {
             return Err(format_err!("could not download {:?}: {}", uri, status));
         }

--- a/guide/src/installation.md
+++ b/guide/src/installation.md
@@ -56,11 +56,20 @@ If you're running on Google, and you have a cluster named `falconeri` in `$CLUST
 
 ```sh
 gcloud container node-pools create falconeri-workers \
-    --cluster=falconeri --disk-size=1000 --enable-autorepair \
-    --machine-type=n1-standard-8 --node-version=1.10.5-gke.0 \
-    --node-labels=node_type=falconeri_worker --disk-type pd-ssd \
+    --cluster=falconeri --disk-size=500 --enable-autorepair \
+    --machine-type=n1-standard-8 --node-version=1.11.6-gke.6 \
+    --node-taints=fdy.io/falconeri=worker:NoExecute \
+    --node-labels=fdy.io/falconeri=worker --disk-type pd-ssd \
     --num-nodes=0 --enable-autoscaling --min-nodes=0 --max-nodes=25 \
     --zone=$CLUSTER_ZONE --scopes=gke-default,storage-rw
+```
+
+Then, add the following to each of your pipeline JSON files:
+
+```json
+  "node_selector": {
+    "fdy.io/falconeri": "worker"
+  },
 ```
 
 Strictly speaking, this is optional. But in practice, autoscaling is extremely convenient, and isolating the workers to a separate node pool will reduce the risk of a runaway worker process "evicting" critical Kubernetes infrastructure.

--- a/guide/src/installation.md
+++ b/guide/src/installation.md
@@ -56,12 +56,20 @@ If you're running on Google, and you have a cluster named `falconeri` in `$CLUST
 
 ```sh
 gcloud container node-pools create falconeri-workers \
-    --cluster=falconeri --disk-size=500 --enable-autorepair \
-    --machine-type=n1-standard-8 --node-version=1.11.6-gke.6 \
+    --cluster=falconeri \
+    --disk-size=500 \
+    --enable-autorepair \
+    --machine-type=n1-standard-8 \
+    --node-version=1.11.6-gke.6 \
     --node-taints=fdy.io/falconeri=worker:NoExecute \
-    --node-labels=fdy.io/falconeri=worker --disk-type pd-ssd \
-    --num-nodes=0 --enable-autoscaling --min-nodes=0 --max-nodes=25 \
-    --zone=$CLUSTER_ZONE --scopes=gke-default,storage-rw
+    --node-labels=fdy.io/falconeri=worker \
+    --disk-type pd-ssd \
+    --num-nodes=0 \
+    --enable-autoscaling \
+    --min-nodes=0 \
+    --max-nodes=25 \
+    --zone=$CLUSTER_ZONE \
+    --scopes=gke-default,storage-rw
 ```
 
 Then, add the following to each of your pipeline JSON files:


### PR DESCRIPTION
If you aren't familiar with `falconeri`, see [the manual](https://faradayio.github.io/falconeri/). This is an open source project, so this PR is public.

This patch adds several features inspired by rough compatibility with [these docs](https://pachyderm.readthedocs.io/en/latest/), plus a few new ergonomic features and an important fix added during our latest big cluster run.

This is a pretty huge PR, because it's a grab-bag of all the things we needed to run a much more complex and demanding task on `falconeri`, one which we had hoped to declare "out of scope" and never support. But it worked, so that's good.

Changes include:

- COMPAT: We support `"input"` types `"cross"` and `"union"`. This forces us to disable the subcommand `job schema`, which generates a JSON schema for pipeline JSON files, because the types involved are now recursive and that breaks the schema library we're using.
- COMPAT: We now handle `glob: "/"` in addition to `"glob": "/*"`.
- COMPAT: We add support for syncing down directories from Google Cloud Storage buckets, instead of just files. This makes it possible to add "collect" steps.
- ERGONOMIC: We use background worker threads to capture the stdout and stderr of the command we run (using custom `*_tee`) routines, so that we can both pass it through normally _and_ add it to the `falconeri datum describe` output.
- MISC: We clean up the `reset_work_dir` code to be a little less cute and to use boring `std` library APIs instead of `glob`.
- SCALING: We increase the amount of RAM available to the `falconeri` controller PostgreSQL deployment, and allow far more inbound connections.
- BUG FIX: We _finally_ fix the known, long-standing PostgreSQL persistence issue using by adding `subPath` to the volume mount declaration, and mounting on `/var/lib/postgresql/data`.
- ERGONOMIC: We make autoscaling integration much more reliable by adding the [toleration](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) `fdy.io/falconeri=worker:NoExecute` to all our worker pods, and document how a cluster admin can use this to create a reserved worker node pool that Kubernetes shoudn't accidentally use for anything else.

As before, `falconeri`'s test coverage is lighter than it should be, because much of it can only be tested using integration tests, and I haven't yet taken the time to figure out how to integration test something that relies on an actual working Kubernetes cluster. We'll do that at some point!
