### PR TITLE
Clean up jobs with ttlSecondsAfterFinished and timeout jobs with activeDeadlineSeconds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,13 +517,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "falconeri"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "falconeri_common 0.2.10",
+ "falconeri_common 0.2.11",
  "handlebars 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -538,12 +538,12 @@ dependencies = [
 
 [[package]]
 name = "falconeri-worker"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "crossbeam 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "falconeri_common 0.2.10",
+ "falconeri_common 0.2.11",
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "falconeri_common"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "backoff 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -579,10 +579,10 @@ dependencies = [
 
 [[package]]
 name = "falconerid"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "falconeri_common 0.2.10",
+ "falconeri_common 0.2.11",
  "headers 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/falconeri-worker/Cargo.toml
+++ b/falconeri-worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "falconeri-worker"
-version = "0.2.10"
+version = "0.2.11"
 authors = ["Eric Kidd <git@randomhacks.net>"]
 edition = "2018"
 

--- a/falconeri/Cargo.toml
+++ b/falconeri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Eric Kidd <git@randomhacks.net>"]
 name = "falconeri"
-version = "0.2.10"
+version = "0.2.11"
 edition = "2018"
 
 [dependencies]

--- a/falconeri_common/Cargo.toml
+++ b/falconeri_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "falconeri_common"
-version = "0.2.10"
+version = "0.2.11"
 authors = ["Eric Kidd <git@randomhacks.net>"]
 edition = "2018"
 

--- a/falconeri_common/src/pipeline.rs
+++ b/falconeri_common/src/pipeline.rs
@@ -44,6 +44,17 @@ pub struct Transform {
     pub cmd: Vec<String>,
     /// The Docker image to run.
     pub image: String,
+    /// After how many seconds to kill the job. Sets activeDeadlineSeconds. See
+    /// https://kubernetes.io/docs/concepts/workloads/controllers/job/#job-termination-and-cleanup
+    /// CAVEAT: Since falconeri doesn't have a babysitter, it won't notice if
+    /// you time out jobs with activeDeadlineSeconds. This is still probably
+    /// better than the alternative - forever running jobs - but be warned that
+    /// you will have to manually clean up jobs that fail like this.
+    pub active_deadline_seconds: Option<String>,
+    /// After how many seconds to clean up completed jobs (so your cluster
+    /// backplane doesn't fill up.) Sets ttlSecondsAfterFinished. See
+    /// https://kubernetes.io/docs/concepts/workloads/controllers/job/#clean-up-finished-jobs-automatically
+    pub ttl_seconds_after_finished: Option<String>,
     /// EXTENSION: When should we pull this image?
     pub image_pull_policy: Option<String>,
     /// Extra environment variables to pass in.

--- a/falconerid/Cargo.toml
+++ b/falconerid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "falconerid"
-version = "0.2.10"
+version = "0.2.11"
 authors = ["Eric Kidd <git@randomhacks.net>"]
 edition = "2018"
 

--- a/falconerid/src/job_manifest.yml.hbs
+++ b/falconerid/src/job_manifest.yml.hbs
@@ -10,6 +10,12 @@ metadata:
   labels:
     "created-by": "falconeri"
 spec:
+{{#if pipeline_spec.transform.active_deadline_seconds}}
+  activeDeadlineSeconds: {{pipeline_spec.transform.active_deadline_seconds}}
+{{/if}}
+{{#if pipeline_spec.transform.ttl_seconds_after_finished}}
+  ttlSecondsAfterFinished: {{pipeline_spec.transform.ttl_seconds_after_finished}}
+{{/if}}
   parallelism: {{pipeline_spec.parallelism_spec.constant}}
   template:
     metadata:


### PR DESCRIPTION
CAVEAT: Since falconeri doesn't have a babysitter, it won't notice if you time out jobs with activeDeadlineSeconds. This is still probably better than the alternative - forever running jobs - but be warned that you will have to manually clean up jobs that fail like this.

ttlSecondsAfterFinished:
* tells Kubernetes 1.21 and above to clean up a job N seconds after it's completed, so your backplane doesn't fill up
* set it in the transform section with ttl_seconds_after_finished
* fixes https://github.com/faradayio/falconeri/issues/26

activeDeadlineSeconds:
* tells Kubernetes to kill a job if it runs for longer than N seconds
* set it in the transform section with active_deadline_seconds
* fixes https://github.com/faradayio/falconeri/issues/27