### PR TITLE
Implement basic babysitter & retry datums according to `datum_tries`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - If worker pod disappears off the cluster while processing a datum, detect this and set the datum to `status = Status::Error`. This is handled automatically by a "babysitter" thread in `falconerid`.
-- Periodically check to see whether a job has finished.
 - Add support for `datum_tries` in the pipeline JSON. Set this to 2, 3, etc., to automatically retry failed datums. This is also handled by the babysitter.
+- Periodically check to see whether a job has finished without being correctly marked as such. This is mostly intended to clean up existing clusters.
+- Periodically check to see whether a Kubernetes job has unexpectedly disappeared, and mark the corresponding `falconeri` job as having failed.
 - Add trace spans for most low-level database access.
 
 ## [0.2.13] - 2021-11-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- If worker pod disappears off the cluster while processing a datum, detect this and set the datum to `status = Status::Error`. This is handled automatically by a "babysitter" thread in `falconerid`.
+- Periodically check to see whether a job has finished.
+- Add support for `datum_tries` in the pipeline JSON. Set this to 2, 3, etc., to automatically retry failed datums. This is also handled by the babysitter.
+- Add trace spans for most low-level database access.
+
 ## [0.2.13] - 2021-11-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+This release adds a "babysitter" process inside each `falconerid`. We use this to monitor jobs and datums, and detect and/or recover from various types of errors. Updating an existing cluster _should_ be fine, but it's likely to spend a minute or two detecting and marking problems with old jobs. So please exercise appropriate caution.
+
+We plan to stabilize a `falconeri` 1.0 with approximately this feature set. It has been in production for years, and the babysitter was the last missing critical feature.
+
 ### Added
 
 - If worker pod disappears off the cluster while processing a datum, detect this and set the datum to `status = Status::Error`. This is handled automatically by a "babysitter" thread in `falconerid`.
@@ -14,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Periodically check to see whether a job has finished without being correctly marked as such. This is mostly intended to clean up existing clusters.
 - Periodically check to see whether a Kubernetes job has unexpectedly disappeared, and mark the corresponding `falconeri` job as having failed.
 - Add trace spans for most low-level database access.
+
+### Fixed
+
+- We now correctly update `updated_at` on all tables that have it.
 
 ## [0.2.13] - 2021-11-23
 

--- a/TODO.org
+++ b/TODO.org
@@ -14,9 +14,11 @@
 * DONE Polishing
 ** DONE prefix
 ** DONE rustfmt
-* TODO Write a basic manual
-
+* DONE Write a basic manual
 * TODO Figure out how to set /pfs and /scratch to SSD drives on Google cloud
 * TODO Handlebars escape functions
 ** TODO Plain text to fix &quot; in `description` output
-** TODO YAML for templates
+** DONE YAML for templates
+* TODO Bugs & regressions
+** TODO Text output for `describe`, `list`, etc., is a mess.
+** TODO Rocket complains about environments at startup, and Rocket logging isn't set up.

--- a/examples/word-frequencies/word-frequencies.json
+++ b/examples/word-frequencies/word-frequencies.json
@@ -9,7 +9,7 @@
             "word-frequencies.sh"
         ],
         "env": {
-            "RUST_LOG": "info"
+            "RUST_LOG": "falconeri_common=debug,falconeri_worker=debug,info"
         },
         "secrets": [
             {
@@ -31,6 +31,7 @@
         "memory": "128Mi",
         "cpu": 0.1
     },
+    "datum_tries": 3,
     "input": {
         "atom": {
           "repo": "texts",

--- a/falconeri/src/cmd/datum/describe.txt.hbs
+++ b/falconeri/src/cmd/datum/describe.txt.hbs
@@ -8,6 +8,7 @@ Pod Name: {{datum.pod_name}}
 {{~ #if datum.node_name}}
 Node Name: {{datum.node_name}}
 {{~ /if}}
+Tries: {{datum.attempted_run_count}}/{{datum.maximum_allowed_run_count}}
 
 Input Files:
 {{~ #each input_files}}

--- a/falconeri/src/cmd/job/describe.rs
+++ b/falconeri/src/cmd/job/describe.rs
@@ -11,7 +11,7 @@ const DESCRIBE_TEMPLATE: &str = include_str!("describe.txt.hbs");
 #[derive(Serialize)]
 struct Params {
     job: Job,
-    datum_status_counts: Vec<(Status, u64)>,
+    datum_status_counts: Vec<DatumStatusCount>,
     running_datums: Vec<Datum>,
     error_datums: Vec<Datum>,
 }
@@ -39,8 +39,16 @@ pub fn run(job_name: &str) -> Result<()> {
 #[test]
 fn render_template() {
     let job = Job::factory();
-    let datum_status_counts =
-        vec![(Status::Ready, 1), (Status::Running, 1), (Status::Error, 1)];
+    let dsc = |status: Status, count: u64, rerunable_count: u64| DatumStatusCount {
+        status,
+        count,
+        rerunable_count,
+    };
+    let datum_status_counts = vec![
+        dsc(Status::Ready, 1, 0),
+        dsc(Status::Running, 1, 0),
+        dsc(Status::Error, 2, 1),
+    ];
     let mut running_datum = Datum::factory(&job);
     running_datum.status = Status::Running;
     let running_datums = vec![running_datum];

--- a/falconeri/src/cmd/job/describe.txt.hbs
+++ b/falconeri/src/cmd/job/describe.txt.hbs
@@ -7,7 +7,7 @@ Egress URI: {{job.egress_uri}}
 
 Datum status:
 {{~ #each datum_status_counts}}
-  {{this.0}}: {{this.1}}
+  {{status}}: {{count}}{{#if rerunable_count}} ({{rerunable_count}} to retry){{/if}}
 {{~ /each}}
 {{~ #if running_datums}}
 

--- a/falconeri_common/migrations/2021-11-23-163415_add_datum_run_counts/down.sql
+++ b/falconeri_common/migrations/2021-11-23-163415_add_datum_run_counts/down.sql
@@ -1,0 +1,5 @@
+DROP INDEX jobs_status_id;
+
+ALTER TABLE datums
+    DROP attempted_run_count,
+    DROP maximum_allowed_run_count;

--- a/falconeri_common/migrations/2021-11-23-163415_add_datum_run_counts/up.sql
+++ b/falconeri_common/migrations/2021-11-23-163415_add_datum_run_counts/up.sql
@@ -1,0 +1,13 @@
+-- Add retry-related columns to `datums`.
+ALTER TABLE datums
+    ADD attempted_run_count integer NOT NULL DEFAULT 0,
+    ADD maximum_allowed_run_count integer NOT NULL DEFAULT 1;
+
+-- If an existing datum is in any state but 'ready', that means we attempted to
+-- run it. So set a reasonable value here.
+UPDATE datums
+    SET attempted_run_count = 1
+    WHERE "status" != 'ready';
+
+-- Index jobs on status so we can look up running jobs and join them to datums.
+CREATE INDEX jobs_status_id ON jobs (status, id);

--- a/falconeri_common/src/example_pipeline_spec.json
+++ b/falconeri_common/src/example_pipeline_spec.json
@@ -31,6 +31,7 @@
     "memory": "500Mi",
     "cpu": 1.2
   },
+  "datum_tries": 3,
   "job_timeout": "5m",
   "node_selector": {
     "node_type": "falconeri_worker"

--- a/falconeri_common/src/kubernetes.rs
+++ b/falconeri_common/src/kubernetes.rs
@@ -169,15 +169,15 @@ pub fn get_running_pod_names() -> Result<HashSet<String>> {
 /// Get a set of all job names present on the cluster.
 #[tracing::instrument(level = "trace")]
 pub fn get_all_job_names() -> Result<HashSet<String>> {
-    let pods = kubectl_parse_json::<ItemsJson<ResourceJson>>(&[
+    let jobs = kubectl_parse_json::<ItemsJson<ResourceJson>>(&[
         "get",
         "jobs",
         "--output=json",
     ])?;
 
     let mut names = HashSet::new();
-    for pod in &pods.items {
-        if let Some(name) = pod.name() {
+    for job in &jobs.items {
+        if let Some(name) = job.name() {
             names.insert(name.to_owned());
         } else {
             warn!("found nameless job");

--- a/falconeri_common/src/models/datum.rs
+++ b/falconeri_common/src/models/datum.rs
@@ -1,3 +1,4 @@
+use crate::kubernetes;
 use crate::prelude::*;
 use crate::schema::*;
 
@@ -25,10 +26,21 @@ pub struct Datum {
     pub backtrace: Option<String>,
     /// Combined stdout and stderr of the code which processed the datum.
     pub output: Option<String>,
+    /// How many times have we tried to process this datum (counting attempts in
+    /// progress)?
+    pub attempted_run_count: i32,
+    /// How many times are we allowed to attempt to process this datum before
+    /// failing for good?
+    ///
+    /// We store this on the `datum`, not the `job`, because (1) it simplifies
+    /// several queries, and (2) it gives us the option of allowing extra
+    /// retries on a particular datum someday.
+    pub maximum_allowed_run_count: i32,
 }
 
 impl Datum {
     /// Find a datum by ID.
+    #[tracing::instrument(skip(conn), level = "trace")]
     pub fn find(id: Uuid, conn: &PgConnection) -> Result<Datum> {
         datums::table
             .find(id)
@@ -36,7 +48,70 @@ impl Datum {
             .with_context(|| format!("could not load datum {}", id))
     }
 
+    /// Find all datums with the specified status that belong to a running job.
+    #[tracing::instrument(skip(conn), level = "trace")]
+    pub fn active_with_status(
+        status: Status,
+        conn: &PgConnection,
+    ) -> Result<Vec<Datum>> {
+        let datums = datums::table
+            .inner_join(jobs::table)
+            .filter(jobs::status.eq(Status::Running))
+            .filter(datums::status.eq(status))
+            .select(datums::all_columns)
+            .load::<Datum>(conn)
+            .with_context(|| {
+                format!("could not load datums with status {}", status)
+            })?;
+        Ok(datums)
+    }
+
+    /// Find datums which claim to be running, but whose `pod_name` points to a
+    /// non-existant pod.
+    #[tracing::instrument(skip(conn), level = "trace")]
+    pub fn zombies(conn: &PgConnection) -> Result<Vec<Datum>> {
+        let running = Self::active_with_status(Status::Running, conn)?;
+        trace!("running datums: {:?}", running);
+        let running_pod_names = kubernetes::running_pod_names()?;
+        Ok(running
+            .into_iter()
+            .filter(|datum| match &datum.pod_name {
+                Some(pod_name) => !running_pod_names.contains(pod_name),
+                None => {
+                    warn!("datum {} has status=\"running\" but no pod_name", datum.id);
+                    true
+                }
+            })
+            .collect::<Vec<_>>())
+    }
+
+    /// Find all datums which have errored, but that we can re-run.
+    ///
+    /// This will only return datums associated with running-jobs.
+    #[tracing::instrument(skip(conn), level = "trace")]
+    pub fn rerunable(conn: &PgConnection) -> Result<Vec<Datum>> {
+        let datums = datums::table
+            .inner_join(jobs::table)
+            .filter(jobs::status.eq(Status::Running))
+            .filter(datums::status.eq(Status::Error))
+            .filter(datums::attempted_run_count.lt(datums::maximum_allowed_run_count))
+            .select(datums::all_columns)
+            .load::<Datum>(conn)
+            .context("could not load rerunable datums")?;
+        debug!("found {} re-runable jobs", datums.len());
+        Ok(datums)
+    }
+
+    /// Is this datum re-runable, assuming it belongs to a running job?
+    ///
+    /// The logic here should mirror [`Datum::rerunnable`] above, except we don't check the job status.
+    pub fn is_rerunable(&self) -> bool {
+        self.status == Status::Error
+            && self.attempted_run_count < self.maximum_allowed_run_count
+    }
+
     /// Get the input files for this datum.
+    #[tracing::instrument(skip(conn), level = "trace")]
     pub fn input_files(&self, conn: &PgConnection) -> Result<Vec<InputFile>> {
         InputFile::belonging_to(self)
             .order_by(input_files::created_at)
@@ -44,16 +119,35 @@ impl Datum {
             .context("could not load input file")
     }
 
+    /// Lock the underying database row using `SELECT FOR UPDATE`. Must be
+    /// called from within a transaction.
+    #[tracing::instrument(skip(conn), level = "trace")]
+    pub fn lock_for_update(&mut self, conn: &PgConnection) -> Result<()> {
+        *self = datums::table
+            .find(self.id)
+            .for_update()
+            .first(conn)
+            .with_context(|| format!("could not load datum {}", self.id))?;
+        Ok(())
+    }
+
     /// Mark this datum as having been successfully processed.
+    #[tracing::instrument(skip(conn, output), level = "trace")]
     pub fn mark_as_done(&mut self, output: &str, conn: &PgConnection) -> Result<()> {
+        let now = Utc::now().naive_utc();
         *self = diesel::update(datums::table.filter(datums::id.eq(&self.id)))
-            .set((datums::status.eq(&Status::Done), datums::output.eq(output)))
+            .set((
+                datums::updated_at.eq(now),
+                datums::status.eq(&Status::Done),
+                datums::output.eq(output),
+            ))
             .get_result(conn)
             .context("can't mark datum as done")?;
         Ok(())
     }
 
     /// Mark this datum as having been unsuccessfully processed.
+    #[tracing::instrument(skip(conn, output, backtrace), level = "trace")]
     pub fn mark_as_error(
         &mut self,
         output: &str,
@@ -61,8 +155,10 @@ impl Datum {
         backtrace: &str,
         conn: &PgConnection,
     ) -> Result<()> {
+        let now = Utc::now().naive_utc();
         *self = diesel::update(datums::table.filter(datums::id.eq(&self.id)))
             .set((
+                datums::updated_at.eq(now),
                 datums::status.eq(&Status::Error),
                 datums::output.eq(output),
                 datums::error_message.eq(&error_message),
@@ -71,6 +167,31 @@ impl Datum {
             .get_result(conn)
             .context("can't mark datum as having failed")?;
         Ok(())
+    }
+
+    /// Mark this datum as eligible to be re-run another time.
+    ///
+    /// We assume that the datum's row is locked by `lock_for_update` when we
+    /// are called.
+    pub fn mark_as_eligible_for_rerun(&mut self, conn: &PgConnection) -> Result<()> {
+        let now = Utc::now().naive_utc();
+        *self = diesel::update(datums::table.filter(datums::id.eq(&self.id)))
+            .set((
+                datums::updated_at.eq(now),
+                datums::status.eq(&Status::Ready),
+                datums::attempted_run_count.eq(self.attempted_run_count + 1),
+            ))
+            .get_result(conn)
+            .context("can't mark datum as eligible")?;
+        Ok(())
+    }
+
+    /// Update the status of our associate job, if it has finished.
+    ///
+    /// This calls [`Job::update_status_if_done`].
+    pub fn update_job_status_if_done(&self, conn: &PgConnection) -> Result<()> {
+        let mut job = Job::find(self.job_id, conn)?;
+        job.update_status_if_done(conn)
     }
 
     /// Generate a sample value for testing.
@@ -87,6 +208,8 @@ impl Datum {
             pod_name: None,
             backtrace: None,
             output: None,
+            attempted_run_count: 0,
+            maximum_allowed_run_count: 1,
         }
     }
 }
@@ -102,10 +225,14 @@ pub struct NewDatum {
     pub id: Uuid,
     /// The job to which this datum belongs.
     pub job_id: Uuid,
+    /// How many times are we allowed to attempt to process this datum before
+    /// failing for good?
+    pub maximum_allowed_run_count: i32,
 }
 
 impl NewDatum {
     /// Insert new datums into the database.
+    #[tracing::instrument(skip(conn), level = "trace")]
     pub fn insert_all(datums: &[Self], conn: &PgConnection) -> Result<()> {
         diesel::insert_into(datums::table)
             .values(datums)

--- a/falconeri_common/src/models/datum.rs
+++ b/falconeri_common/src/models/datum.rs
@@ -72,7 +72,7 @@ impl Datum {
     pub fn zombies(conn: &PgConnection) -> Result<Vec<Datum>> {
         let running = Self::active_with_status(Status::Running, conn)?;
         trace!("running datums: {:?}", running);
-        let running_pod_names = kubernetes::running_pod_names()?;
+        let running_pod_names = kubernetes::get_running_pod_names()?;
         Ok(running
             .into_iter()
             .filter(|datum| match &datum.pod_name {

--- a/falconeri_common/src/models/input_file.rs
+++ b/falconeri_common/src/models/input_file.rs
@@ -22,6 +22,7 @@ pub struct InputFile {
 impl InputFile {
     /// Fetch all the input files corresponding to `datums`, returning grouped
     /// in the same order.
+    #[tracing::instrument(skip(conn), level = "trace")]
     pub fn for_datums(
         datums: &[Datum],
         conn: &PgConnection,
@@ -62,6 +63,7 @@ pub struct NewInputFile {
 
 impl NewInputFile {
     /// Insert a new job into the database.
+    #[tracing::instrument(skip(conn), level = "trace")]
     pub fn insert_all(input_files: &[Self], conn: &PgConnection) -> Result<()> {
         diesel::insert_into(input_files::table)
             .values(input_files)

--- a/falconeri_common/src/models/job.rs
+++ b/falconeri_common/src/models/job.rs
@@ -30,6 +30,7 @@ pub struct Job {
 
 impl Job {
     /// Find a job by ID.
+    #[tracing::instrument(skip(conn), level = "trace")]
     pub fn find(id: Uuid, conn: &PgConnection) -> Result<Job> {
         jobs::table
             .find(id)
@@ -38,6 +39,7 @@ impl Job {
     }
 
     /// Find a job by job name.
+    #[tracing::instrument(skip(conn), level = "trace")]
     pub fn find_by_job_name(job_name: &str, conn: &PgConnection) -> Result<Job> {
         jobs::table
             .filter(jobs::job_name.eq(job_name))
@@ -45,7 +47,17 @@ impl Job {
             .with_context(|| format!("could not load job {:?}", job_name))
     }
 
+    /// Find all jobs with specified status.
+    #[tracing::instrument(skip(conn), level = "trace")]
+    pub fn find_by_status(status: Status, conn: &PgConnection) -> Result<Vec<Job>> {
+        jobs::table
+            .filter(jobs::status.eq(status))
+            .load(conn)
+            .with_context(|| format!("could not load jobs with status {}", status))
+    }
+
     /// Get all known jobs.
+    #[tracing::instrument(skip(conn), level = "trace")]
     pub fn list(conn: &PgConnection) -> Result<Vec<Job>> {
         jobs::table
             .order_by(jobs::created_at.desc())
@@ -55,6 +67,7 @@ impl Job {
 
     /// Look up the next datum available to process, and set the status to
     /// `"processing"`. This is intended to be atomic from an SQL perspective.
+    #[tracing::instrument(skip(conn), level = "trace")]
     pub fn reserve_next_datum(
         &self,
         node_name: &str,
@@ -92,6 +105,7 @@ impl Job {
     ///
     /// But if the reservation has been made at the database layer, we can make
     /// the reservation idempotent by looking for an existing reservation.
+    #[tracing::instrument(skip(conn), level = "trace")]
     fn find_already_reserved_datum(
         &self,
         pod_name: &str,
@@ -110,6 +124,7 @@ impl Job {
 
     /// Internal helper for `reserve_next_datum` which performs the actual
     /// atomic reservation part itself, if we actually need to do so.
+    #[tracing::instrument(skip(conn), level = "trace")]
     fn actually_reserve_next_datum(
         &self,
         node_name: &str,
@@ -131,11 +146,15 @@ impl Job {
                 .context("error trying to reserve next datum")?;
             if let Some(datum_id) = datum_id {
                 let to_update = datums::table.filter(datums::id.eq(&datum_id));
+                let now = Utc::now().naive_utc();
                 let datum: Datum = diesel::update(to_update)
                     .set((
+                        datums::updated_at.eq(now),
                         datums::status.eq(&Status::Running),
                         datums::node_name.eq(&Some(node_name)),
                         datums::pod_name.eq(&Some(pod_name)),
+                        datums::attempted_run_count
+                            .eq(datums::attempted_run_count + 1),
                     ))
                     .get_result(conn)
                     .context("cannot mark datum as 'processing'")?;
@@ -147,19 +166,24 @@ impl Job {
     }
 
     /// Get the number of datums with each status.
+    #[tracing::instrument(skip(conn), level = "trace")]
     pub fn datum_status_counts(
         &self,
         conn: &PgConnection,
-    ) -> Result<Vec<(Status, u64)>> {
+    ) -> Result<Vec<DatumStatusCount>> {
         // Look up how many
-        let raw_status_counts: Vec<(Status, i64)> = Datum::belonging_to(&*self)
+        let raw_status_counts: Vec<(Status, i64, i64)> = Datum::belonging_to(&*self)
             // Diesel doesn't fully support `GROUP BY`, but we can use the
             // undocumented `group_by` method and the `dsl::sql` helper to build
             // the query anyways. For details, see
             // https://github.com/diesel-rs/diesel/issues/210
             .group_by(datums::status)
-            .select(dsl::sql::<(sql_types::Status, diesel::sql_types::BigInt)>(
-                "status, count(*)",
+            .select(dsl::sql::<(
+                sql_types::Status,
+                diesel::sql_types::BigInt,
+                diesel::sql_types::BigInt,
+            )>(
+                "status, count(*), count(*) filter (where status = 'error' and attempted_run_count < maximum_allowed_run_count)",
             ))
             .order_by(datums::status)
             .load(conn)
@@ -167,13 +191,20 @@ impl Job {
 
         raw_status_counts
             .into_iter()
-            .filter(|&(_status, count)| count > 0)
-            .map(|(status, count)| Ok((status, cast::u64(count)?)))
+            .filter(|&(_status, count, _rerunable_count)| count > 0)
+            .map(|(status, count, rerunable_count)| {
+                Ok(DatumStatusCount {
+                    status,
+                    count: cast::u64(count)?,
+                    rerunable_count: cast::u64(rerunable_count)?,
+                })
+            })
             .collect::<Result<_>>()
     }
 
     /// Get all our our currently running datums (the ones being processed by
     /// a worker somewhere).
+    #[tracing::instrument(skip(conn), level = "trace")]
     pub fn datums_with_status(
         &self,
         status: Status,
@@ -188,7 +219,8 @@ impl Job {
 
     /// Lock the underying database row using `SELECT FOR UPDATE`. Must be
     /// called from within a transaction.
-    fn lock_for_update(&mut self, conn: &PgConnection) -> Result<()> {
+    #[tracing::instrument(skip(conn), level = "trace")]
+    pub fn lock_for_update(&mut self, conn: &PgConnection) -> Result<()> {
         *self = jobs::table
             .find(self.id)
             .for_update()
@@ -198,12 +230,13 @@ impl Job {
     }
 
     /// Update the overall job status if there's nothing left to do.
+    #[tracing::instrument(skip(conn), level = "trace")]
     pub fn update_status_if_done(&mut self, conn: &PgConnection) -> Result<()> {
         trace!("querying for status of datums for job {}", self.id);
         conn.transaction(|| {
             // Lock this job for update. This isn't necessary for this routine
             // by itself, but it should help avoid race conditions with job
-            // retries.
+            // retries and the babysitter.
             self.lock_for_update(conn)?;
             if self.status != Status::Running {
                 // Nothing to do, so return immediately.
@@ -216,24 +249,38 @@ impl Job {
             let mut unfinished = 0;
             let mut successful = 0;
             let mut failed = 0;
-            for (status, count) in status_counts {
-                match status {
+            let mut rerunable = 0;
+            for status_count in status_counts {
+                match status_count.status {
                     Status::Ready | Status::Running => {
-                        unfinished += count;
+                        assert_eq!(status_count.rerunable_count, 0);
+                        unfinished += status_count.count;
                     }
                     Status::Done => {
-                        successful += count;
+                        assert_eq!(status_count.rerunable_count, 0);
+                        successful += status_count.count;
                     }
+                    Status::Error => {
+                        assert!(status_count.rerunable_count <= status_count.count);
+                        failed += status_count.count - status_count.rerunable_count;
+                        rerunable += status_count.rerunable_count;
+                    }
+
                     // TODO: Be smarted about `Canceled` once we implement it.
-                    Status::Error | Status::Canceled => {
-                        failed += count;
+                    Status::Canceled => {
+                        assert_eq!(status_count.rerunable_count, 0);
+                        failed += status_count.count;
                     }
                 }
             }
 
             // Decide what to do, if anything.
-            let job_status = if unfinished > 0 {
-                trace!("{} datums remaining, not updating job status", unfinished);
+            let job_status = if unfinished > 0 || rerunable > 0 {
+                trace!(
+                    "{} datums remaining, {} rerunable, not updating job status",
+                    unfinished,
+                    rerunable
+                );
                 None
             } else if failed > 0 {
                 debug!("{} datums had errors, marking job as error", failed);
@@ -246,9 +293,10 @@ impl Job {
                 Some(Status::Done)
             };
             if let Some(job_status) = job_status {
+                let now = Utc::now().naive_utc();
                 *self = diesel::update(jobs::table)
                     .filter(jobs::id.eq(&self.id))
-                    .set(jobs::status.eq(&job_status))
+                    .set((jobs::status.eq(&job_status), jobs::updated_at.eq(now)))
                     .get_result(conn)
                     .context("could not update job status")?;
             }
@@ -273,6 +321,18 @@ impl Job {
     }
 }
 
+/// The number of datums with a specified status, plus how many are retryable.
+#[derive(Debug, Queryable, Serialize)]
+pub struct DatumStatusCount {
+    /// The status we're counting.
+    pub status: Status,
+    /// The number of datums with this status.
+    pub count: u64,
+    /// The number of datums which could be re-run. This will be zero if
+    /// `status` is not `Status::Error`.
+    pub rerunable_count: u64,
+}
+
 /// Data required to create a new `Job`.
 #[derive(Debug, Insertable)]
 #[table_name = "jobs"]
@@ -291,6 +351,7 @@ pub struct NewJob {
 
 impl NewJob {
     /// Insert a new job into the database.
+    #[tracing::instrument(skip(conn), level = "trace")]
     pub fn insert(&self, conn: &PgConnection) -> Result<Job> {
         diesel::insert_into(jobs::table)
             .values(self)

--- a/falconeri_common/src/pipeline.rs
+++ b/falconeri_common/src/pipeline.rs
@@ -23,6 +23,8 @@ pub struct PipelineSpec {
     pub parallelism_spec: ParallelismSpec,
     /// How many resources should we allocate for each worker?
     pub resource_requests: ResourceRequests,
+    /// The maximum number of times to retry a single datum.
+    pub datum_tries: Option<u32>,
     /// Timeout a running job after this many seconds have elapsed.
     #[serde(default, with = "humantime_serde")]
     pub job_timeout: Option<Duration>,
@@ -214,6 +216,7 @@ fn parse_pipeline_spec() {
     assert_eq!(parsed.parallelism_spec.constant, 10);
     assert_eq!(parsed.resource_requests.memory, "500Mi");
     assert!((parsed.resource_requests.cpu - 1.2).abs() < f32::EPSILON);
+    assert_eq!(parsed.datum_tries, Some(3));
     assert_eq!(parsed.job_timeout, Some(Duration::from_secs(300)));
     assert_eq!(parsed.node_selector["node_type"], "falconeri_worker");
     assert_eq!(parsed.transform.image, "somerepo/my_python_nlp");

--- a/falconeri_common/src/schema.rs
+++ b/falconeri_common/src/schema.rs
@@ -13,6 +13,8 @@ table! {
         pod_name -> Nullable<Text>,
         backtrace -> Nullable<Text>,
         output -> Nullable<Text>,
+        attempted_run_count -> Int4,
+        maximum_allowed_run_count -> Int4,
     }
 }
 

--- a/falconerid/src/babysitter.rs
+++ b/falconerid/src/babysitter.rs
@@ -1,0 +1,156 @@
+//! A background process which tries to keep an eye on running jobs.
+//!
+//! We only store state in Postgres, and we assume that:
+//!
+//! 1. Any process can fail at any time, and
+//! 2. **More than one copy of the babysitter will normally be running.**
+//!
+//! Using PostgreSQL to store state is one of the simplest ways to build a
+//! medium-reliability, small-scale distributed job system.
+
+use std::{panic::catch_unwind, process, thread, time::Duration};
+
+use falconeri_common::{db, prelude::*, tracing};
+
+/// Spawn a thread and run the babysitter in it. This should run indefinitely.
+#[tracing::instrument(level = "trace")]
+pub fn start_babysitter() -> Result<thread::JoinHandle<()>> {
+    let builder = thread::Builder::new().name("babysitter".to_owned());
+    builder
+        .spawn(run_babysitter_wrapper)
+        .context("could not create babysitter thread")
+}
+
+/// Run the babysitter, and abort if we catch any panics.
+#[tracing::instrument(level = "trace")]
+fn run_babysitter_wrapper() {
+    // If this thread panics, attempt to shut down the entire process, forcing
+    // Kubernetes to make noise and restart this `falconerid`. The last thing we
+    // want is for the babysitter to silently fail.
+    //
+    // And no, Rust does not make it nice to catch panics. We're supposed to
+    // used `Result` for any kind of ordinary error handling, and reserve
+    // `panic!` for assertion-failure-like errors.
+    if let Err(err) = catch_unwind(run_babysitter) {
+        // Extract information about the panic, if it's one of the common types.
+        let msg = if let Some(msg) = err.downcast_ref::<&str>() {
+            // Created by `panic!("fixed string")`.
+            *msg
+        } else if let Some(msg) = err.downcast_ref::<String>() {
+            // Created by `panic!("format string: {}", "with arguments")`.
+            msg
+        } else {
+            // There's really nothing better we can do here.
+            "an unknown panic occurred"
+        };
+
+        // Log and print this just in case, so everyone knows what's happening,
+        // regardless of whether logs are enabled or where they are sent.
+        error!("BABYSITTER PANIC, aborting: {}", msg);
+        eprintln!("BABYSITTER PANIC, aborting: {}", msg);
+        process::abort();
+    }
+}
+
+/// Actually run the babysitter.
+#[tracing::instrument(level = "trace")]
+fn run_babysitter() {
+    loop {
+        // We always want to retry all errors. This way, if PostgreSQL is still
+        // starting up, or if someone retarted it, we'll eventually recover.
+        if let Err(err) = check_running_jobs() {
+            error!(
+                "error checking running jobs (will retry later): {}",
+                err.display_causes_and_backtrace()
+            );
+        }
+        thread::sleep(Duration::from_secs(2 * 60));
+    }
+}
+
+/// Check our running jobs for various situations we might might need to deal
+/// with.
+#[tracing::instrument(level = "debug")]
+fn check_running_jobs() -> Result<()> {
+    let conn = db::connect(ConnectVia::Cluster)?;
+    check_for_finished_jobs(&conn)?;
+    check_for_zombie_datums(&conn)?;
+    // Note that any datums marked as `Status::Error` by
+    // `check_for_zombie_datums` above may then be retried normally by
+    // `check_for_datums_which_can_be_rerun` (if they're eligible).
+    check_for_datums_which_can_be_rerun(&conn)
+}
+
+/// Check for jobs which should be marked as finished.
+///
+/// This should normally happen automatically, but if it doesn't, we'll catch it
+/// here.
+#[tracing::instrument(skip(conn), level = "debug")]
+fn check_for_finished_jobs(conn: &PgConnection) -> Result<()> {
+    let jobs = Job::find_by_status(Status::Running, conn)?;
+    for mut job in jobs {
+        job.update_status_if_done(conn)?;
+    }
+    Ok(())
+}
+
+/// Check for datums which claim to be running in a pod that no longer exists.
+#[tracing::instrument(skip(conn), level = "debug")]
+fn check_for_zombie_datums(conn: &PgConnection) -> Result<()> {
+    let zombies = Datum::zombies(conn)?;
+    for mut zombie in zombies {
+        // We may be racing a second copy of the babysitter here, so start a
+        // transaction, take a lock, and double-check that our status is still
+        // `Status::Running`.
+        conn.transaction(|| -> Result<()> {
+            zombie.lock_for_update(conn)?;
+            if zombie.status == Status::Running {
+                warn!(
+                    "found zombie datum {}, which was supposed to be running on pod {:?}",
+                    zombie.id, zombie.pod_name
+                );
+                zombie.mark_as_error(
+                    "(did not capture output)",
+                    "worker pod disappeared while working on datum",
+                    "(no backtrace available)",
+                    conn,
+                )?;
+            } else {
+                warn!("someone beat us to zombie datum {}", zombie.id);
+            }
+            Ok(())
+        })?;
+        // If there are no more datums, mark the job as finished (either
+        // done or error).
+        zombie.update_job_status_if_done(conn)?;
+    }
+    Ok(())
+}
+
+/// Check for datums which are in the error state but which are eligible for
+/// retries.
+#[tracing::instrument(skip(conn), level = "debug")]
+fn check_for_datums_which_can_be_rerun(conn: &PgConnection) -> Result<()> {
+    let rerunable_datums = Datum::rerunable(conn)?;
+    for mut datum in rerunable_datums {
+        // We may be racing a second copy of the babysitter here, so start a
+        // transaction, take a lock, and double-check that we're still eligible
+        // for a re-run.
+        conn.transaction(|| -> Result<()> {
+            datum.lock_for_update(conn)?;
+            if datum.is_rerunable() {
+                warn!(
+                    "rescheduling errored datum {} (previously on try {}/{})",
+                    datum.id,
+                    datum.attempted_run_count,
+                    datum.maximum_allowed_run_count
+                );
+                datum.mark_as_eligible_for_rerun(conn)?;
+            } else {
+                warn!("someone beat us to rerunable datum {}", datum.id);
+            }
+            Ok(())
+        })?;
+    }
+    Ok(())
+}

--- a/falconerid/src/inputs.rs
+++ b/falconerid/src/inputs.rs
@@ -22,11 +22,13 @@ impl DatumData {
     fn into_new_datum_and_input_files(
         self,
         job_id: Uuid,
+        maximum_allowed_run_count: i32,
     ) -> (NewDatum, Vec<NewInputFile>) {
         let datum_id = Uuid::new_v4();
         let datum = NewDatum {
             id: datum_id,
             job_id,
+            maximum_allowed_run_count,
         };
         let input_files = self
             .input_files
@@ -65,12 +67,14 @@ impl InputFileData {
 pub fn input_to_datums(
     secrets: &[Secret],
     job_id: Uuid,
+    maximum_allowed_run_count: i32,
     input: &Input,
 ) -> Result<(Vec<NewDatum>, Vec<NewInputFile>)> {
     let mut all_datums = vec![];
     let mut all_input_files = vec![];
     for datum_data in input_to_datums_helper(secrets, input)? {
-        let (datum, input_files) = datum_data.into_new_datum_and_input_files(job_id);
+        let (datum, input_files) = datum_data
+            .into_new_datum_and_input_files(job_id, maximum_allowed_run_count);
         all_datums.push(datum);
         all_input_files.extend(input_files);
     }


### PR DESCRIPTION
We add support for `datum_tries`. This involves adding a "babysitter" thread to each running copy of `falconerid`. The babysitter wakes up every two minutes, and looks at the running datums and jobs. If anything looks broken, the babysitter fixes it.

Importantly, the babysitter is stateless and it relies on PostgreSQL locks to coordinate all operations. So it's normal to run multiple copies of the babysitter. And it should remain possible (and safe) to restart `falconerid` at any time.