### PR TITLE
[fix] Lock to Postgres 14 for now

### DIFF
--- a/falconeri/src/cmd/deploy_manifest.yml.hbs
+++ b/falconeri/src/cmd/deploy_manifest.yml.hbs
@@ -40,7 +40,7 @@ spec:
     spec:
       containers:
       - name: falconeri-postgres
-        image: postgres
+        image: postgres:14
         # We no longer need a huge number of connections thanks to falconerid,
         # but we might want to tune shared_buffers and maybe kernel.shmmax as
         # well.


### PR DESCRIPTION
We don't want Postgres to automatically update to 15, which will break existing deployments.

- [ ] Do we want to make Postgres version a config option? This would really only affect people who deployed falconeri in the last month or so, and I don't think there are many of them.