### PR TITLE
worker should default to info log level not trace

### DIFF
--- a/falconerid/src/job_manifest.yml.hbs
+++ b/falconerid/src/job_manifest.yml.hbs
@@ -52,7 +52,7 @@ spec:
         - name: RUST_BACKTRACE
           value: "1"
         - name: RUST_LOG
-          value: "falconeri_common=trace,falconeri_worker=trace"
+          value: "falconeri_common=info,falconeri_worker=info"
         - name: FALCONERI_NODE_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
perhaps in the future this should be a setting, but for now let's at least set it to info